### PR TITLE
Prep for v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+#### v0.3.1 - 2017-08-03
+  * Fix Makefile VERSION
+
 #### v0.3.0 - 2017-08-03
   * Initial Release

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # project related vars
 ROOT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 PROJECT = ark
-VERSION ?= v0.3.0
+VERSION ?= v0.3.1
 GOTARGET = github.com/heptio/$(PROJECT)
 OUTPUT_DIR = $(ROOT_DIR)/_output
 BIN_DIR = $(OUTPUT_DIR)/bin


### PR DESCRIPTION
v0.3.0 had a couple of issues (changelog missing date, Makefile had VERSION 0.3.0 when it should have been v0.3.0). #4 and this give us a minor bump to v0.3.1.