### PR TITLE
Add userid to ark alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ kubectl get deployments --namespace=nginx-example
 Finally, create an alias for the Ark client's Docker executable. (Make sure that your `KUBECONFIG` environment variable is pointing at the proper config first). This will save a lot of future typing:
 
 ```
-alias ark='docker run --rm -v $(dirname $KUBECONFIG):/kubeconfig -e KUBECONFIG=/kubeconfig/$(basename $KUBECONFIG) gcr.io/heptio-images/ark:latest'
+alias ark='docker run --rm -u $(id -u) -v $(dirname $KUBECONFIG):/kubeconfig -e KUBECONFIG=/kubeconfig/$(basename $KUBECONFIG) gcr.io/heptio-images/ark:latest'
 ```
 *NOTE*: Depending on how your Kubeconfig is written--if it refers to the Kubernetes API server using the host machine's `localhost`, for instance--you may need to add an additional `--net="host"` flag to the `docker run` command.
 

--- a/docs/cli-reference/README.md
+++ b/docs/cli-reference/README.md
@@ -9,7 +9,7 @@ The Ark client provides a CLI that allows you to initiate ad-hoc backups, schedu
 While it is possible to build and run the `ark` executable yourself, it is recommended to use the containerized version. Use the alias described in the quickstart:
 
 ```
-alias ark='docker run --rm -v $(dirname $KUBECONFIG):/kubeconfig -e KUBECONFIG=/kubeconfig/$(basename $KUBECONFIG) gcr.io/heptio-images/ark:latest'
+alias ark='docker run --rm -u $(id -u) -v $(dirname $KUBECONFIG):/kubeconfig -e KUBECONFIG=/kubeconfig/$(basename $KUBECONFIG) gcr.io/heptio-images/ark:latest'
 ```
 
 Assuming that your `KUBECONFIG` variable is set, this alias takes care of specifying the appropriate Kubernetes cluster credentials for you.


### PR DESCRIPTION
Since the ark container runs as a non-privileged user by default there are cases where it may not be able to read some user's config files if the permissions are more restrictive. Running the ark as the active user will make sure that the config file can be used in all cases.