### PR TITLE
Small documentation fix

### DIFF
--- a/docs/cloud-provider-specifics.md
+++ b/docs/cloud-provider-specifics.md
@@ -290,7 +290,7 @@ Start the sample nginx app:
 ```
 kubectl apply -f examples/nginx-app/base.yaml
 ```
-Now create a backup with PV snapshotting:
+Now create a backup:
 ```
 ark backup create nginx-backup --selector app=nginx
 ```


### PR DESCRIPTION
Removes text about PV snapshotting from the "No PVs" backup section. In those examples the `--snapshot-volumes` argument is not being set. 

Signed-off-by: Andrew Williams <williams.andrew@gmail.com>