### PR TITLE
Add support for S3 SSE with KMS

### DIFF
--- a/docs/config-definition.md
+++ b/docs/config-definition.md
@@ -70,6 +70,7 @@ The configurable parameters are as follows:
 | `disableSSL` | bool | `false` | Set this to `true` if you are using Minio (or another local, S3-compatible storage service) and your deployment is not secured. |
 | `s3ForcePathStyle` | bool | `false` | Set this to `true` if you are using a local storage service like Minio. |
 | `s3Url` | string | Required field for non-AWS-hosted storage| *Example*: http://minio:9000<br><br>You can specify the AWS S3 URL here for explicitness, but Ark can already generate it from `region`, `availabilityZone`, and `bucket`. This field is primarily for local sotrage services like Minio.|
+| `kmsKeyID` | string | Empty | *Example*: "502b409c-4da1-419f-a16e-eif453b3i49f"<br><br>Specify an [AWS KMS key][12] id to enable encryption of the backups stored in S3. Only works with AWS S3 and may require explicitly granting key usage rights.|
 
 ### GCP
 | Key | Type | Default | Meaning |
@@ -95,3 +96,5 @@ The configurable parameters are as follows:
 [9]: #main-config-parameters
 [10]: #overview
 [11]: #example
+[12]: http://docs.aws.amazon.com/kms/latest/developerguide/overview.html
+

--- a/pkg/apis/ark/v1/config.go
+++ b/pkg/apis/ark/v1/config.go
@@ -98,6 +98,7 @@ type AWSConfig struct {
 	DisableSSL       bool   `json:"disableSSL"`
 	S3ForcePathStyle bool   `json:"s3ForcePathStyle"`
 	S3Url            string `json:"s3Url"`
+	KMSKeyID         string `json:"kmsKeyId"`
 }
 
 // GCPConfig is configuration information for connecting to GCP.

--- a/pkg/cloudprovider/aws/storage_adapter.go
+++ b/pkg/cloudprovider/aws/storage_adapter.go
@@ -32,7 +32,7 @@ type storageAdapter struct {
 
 var _ cloudprovider.StorageAdapter = &storageAdapter{}
 
-func NewStorageAdapter(config *aws.Config, availabilityZone string) (cloudprovider.StorageAdapter, error) {
+func NewStorageAdapter(config *aws.Config, availabilityZone string, kmsKeyID string) (cloudprovider.StorageAdapter, error) {
 	sess, err := session.NewSession(config)
 	if err != nil {
 		return nil, err
@@ -48,7 +48,8 @@ func NewStorageAdapter(config *aws.Config, availabilityZone string) (cloudprovid
 			az:  availabilityZone,
 		},
 		objectStorage: &objectStorageAdapter{
-			s3: s3.New(sess),
+			s3:       s3.New(sess),
+			kmsKeyID: kmsKeyID,
 		},
 	}, nil
 }

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -324,7 +324,7 @@ func getAWSCloudProvider(cloudConfig api.CloudProviderConfig) (cloudprovider.Sto
 		)
 	}
 
-	return arkaws.NewStorageAdapter(awsConfig, cloudConfig.AWS.AvailabilityZone)
+	return arkaws.NewStorageAdapter(awsConfig, cloudConfig.AWS.AvailabilityZone, cloudConfig.AWS.KMSKeyID)
 }
 
 func getGCPCloudProvider(cloudConfig api.CloudProviderConfig) (cloudprovider.StorageAdapter, error) {


### PR DESCRIPTION
Issue #24 

If not specified in the configuration, `kmsKeyID` should be an empty string, which gets passed to `PutObjectInput`. Because an empty string is essentially undefined and the AWS SDK checks if a key ID is given, I did not add checks on our side.