### PR TITLE
Schedules: treat 1st cron field as minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+#### v0.3.3 - 2017-08-10
+  * Treat the first field in a schedule's cron expression as minutes, not seconds
+
 #### v0.3.2 - 2017-08-07
   * Add client-go auth provider plugins for Azure, GCP, OIDC
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # project related vars
 ROOT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 PROJECT = ark
-VERSION ?= v0.3.2
+VERSION ?= v0.3.3
 GOTARGET = github.com/heptio/$(PROJECT)
 OUTPUT_DIR = $(ROOT_DIR)/_output
 BIN_DIR = $(OUTPUT_DIR)/bin

--- a/pkg/controller/schedule_controller.go
+++ b/pkg/controller/schedule_controller.go
@@ -300,7 +300,7 @@ func parseCronSchedule(itm *api.Schedule) (cron.Schedule, []string) {
 			}
 		}()
 
-		if res, err := cron.Parse(itm.Spec.Schedule); err != nil {
+		if res, err := cron.ParseStandard(itm.Spec.Schedule); err != nil {
 			glog.V(4).Infof("error parsing schedule %v/%v, cron schedule=%v: %v", itm.Namespace, itm.Name, itm.Spec.Schedule, err)
 			validationErrors = append(validationErrors, fmt.Sprintf("invalid schedule: %v", err))
 		} else {


### PR DESCRIPTION
Fixes #30 

@skriss this also includes the commit to bump to v0.3.3