### PR TITLE
Example of using ThirdPartyResources instead of CustomResourceDefinit…

### DIFF
--- a/examples/common/00-prereqs.yaml
+++ b/examples/common/00-prereqs.yaml
@@ -13,64 +13,44 @@
 # limitations under the License.
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: extensions/v1beta1
+kind: ThirdPartyResource
 metadata:
-  name: backups.ark.heptio.com
+  name: backup.ark.heptio.com
   labels:
     component: ark
-spec:
-  group: ark.heptio.com
-  version: v1
-  scope: Namespaced
-  names:
-    plural: backups
-    kind: Backup
+versions:
+  - name: v1
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: extensions/v1beta1
+kind: ThirdPartyResource
 metadata:
-  name: schedules.ark.heptio.com
+  name: schedule.ark.heptio.com
   labels:
     component: ark
-spec:
-  group: ark.heptio.com
-  version: v1
-  scope: Namespaced
-  names:
-    plural: schedules
-    kind: Schedule
+versions:
+  - name: v1
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: extensions/v1beta1
+kind: ThirdPartyResource
 metadata:
-  name: restores.ark.heptio.com
+  name: restore.ark.heptio.com
   labels:
     component: ark
-spec:
-  group: ark.heptio.com
-  version: v1
-  scope: Namespaced
-  names:
-    plural: restores
-    kind: Restore
+versions:
+  - name: v1
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: extensions/v1beta1
+kind: ThirdPartyResource
 metadata:
-  name: configs.ark.heptio.com
+  name: config.ark.heptio.com
   labels:
     component: ark
-spec:
-  group: ark.heptio.com
-  version: v1
-  scope: Namespaced
-  names:
-    plural: configs
-    kind: Config
+versions:
+  - name: v1
 
 ---
 apiVersion: v1
@@ -108,7 +88,7 @@ rules:
     verbs:
       - create
     resources:
-      - customresourcedefinitions
+      - ThirdPartyResources
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
…ion for migrating a 1.6 cluster to 1.7

This is just an example for documenting what worked for me to migrate 1.6 clusters. It shouldn't be merged.