### PR TITLE
check for namespaces/ dir before reading it

### DIFF
--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -210,6 +210,15 @@ func (kr *kubernetesRestorer) restoreFromDir(
 
 	// namespace-scoped
 	namespacesPath := path.Join(dir, api.NamespaceScopedDir)
+	exists, err = kr.fileSystem.DirExists(namespacesPath)
+	if err != nil {
+		addArkError(&errors, err)
+		return warnings, errors
+	}
+	if !exists {
+		return warnings, errors
+	}
+
 	nses, err := kr.fileSystem.ReadDir(namespacesPath)
 	if err != nil {
 		addArkError(&errors, err)

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -92,6 +92,13 @@ func TestRestoreMethod(t *testing.T) {
 			expectedReadDirs: []string{"bak/cluster", "bak/namespaces"},
 		},
 		{
+			name:             "namespaces dir is not read & does not error if it does not exist",
+			fileSystem:       newFakeFileSystem().WithDirectories("bak/cluster"),
+			baseDir:          "bak",
+			restore:          &api.Restore{Spec: api.RestoreSpec{}},
+			expectedReadDirs: []string{"bak/cluster"},
+		},
+		{
 			name:             "namespacesToRestore having * restores all namespaces",
 			fileSystem:       newFakeFileSystem().WithDirectories("bak/cluster", "bak/namespaces/a", "bak/namespaces/b", "bak/namespaces/c"),
 			baseDir:          "bak",


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

Restoring a backup containing only cluster-scoped resources currently shows an error in the Restore because there is no namespaces/ dir in the backup. Change restorer to check for this and end gracefully if it's not there.