### PR TITLE
Adding in support for backup download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ _testmain.go
 debug
 
 /ark
+.idea/

--- a/docs/cli-reference/ark_backup_download.md
+++ b/docs/cli-reference/ark_backup_download.md
@@ -1,16 +1,23 @@
-## ark backup
+## ark backup download
 
-Work with backups
+Download a backup
 
 ### Synopsis
 
 
-Work with backups
+Download a backup
+
+```
+ark backup download NAME [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for backup
+      --force               forces the download and will overwrite file if it exists already
+  -h, --help                help for download
+      --output-dir string   directory to download backup to. (Default cwd)
+      --timeout duration    maximum time to wait to process download request (default 1m0s)
 ```
 
 ### Options inherited from parent commands
@@ -27,9 +34,5 @@ Work with backups
 ```
 
 ### SEE ALSO
-* [ark](ark.md)	 - Back up and restore Kubernetes cluster resources.
-* [ark backup create](ark_backup_create.md)	 - Create a backup
-* [ark backup download](ark_backup_download.md)	 - Download a backup
-* [ark backup get](ark_backup_get.md)	 - Get backups
-* [ark backup logs](ark_backup_logs.md)	 - Get backup logs
+* [ark backup](ark_backup.md)	 - Work with backups
 

--- a/docs/generate/ark.go
+++ b/docs/generate/ark.go
@@ -18,17 +18,17 @@ package main
 
 import (
 	"log"
-  "os"
+	"os"
 
-	"github.com/spf13/cobra/doc"
 	"github.com/heptio/ark/pkg/cmd/ark"
+	"github.com/spf13/cobra/doc"
 )
 
 func main() {
-  cmdName := os.Args[1]
+	cmdName := os.Args[1]
 	outputDir := os.Args[2]
 
-  cmd := ark.NewCommand(cmdName)
+	cmd := ark.NewCommand(cmdName)
 	// Remove auto-generated timestamps
 	cmd.DisableAutoGenTag = true
 

--- a/pkg/apis/ark/v1/download_request.go
+++ b/pkg/apis/ark/v1/download_request.go
@@ -28,7 +28,8 @@ type DownloadRequestSpec struct {
 type DownloadTargetKind string
 
 const (
-	DownloadTargetKindBackupLog DownloadTargetKind = "BackupLog"
+	DownloadTargetKindBackupLog      DownloadTargetKind = "BackupLog"
+	DownloadTargetKindBackupContents DownloadTargetKind = "BackupContents"
 )
 
 // DownloadTarget is the specification for what kind of file to download, and the name of the

--- a/pkg/buildinfo/version.go
+++ b/pkg/buildinfo/version.go
@@ -25,3 +25,6 @@ var Version string
 // DockerImage is the full path to the docker image for this build, for example
 // gcr.io/heptio-images/ark.
 var DockerImage string
+
+// GitSHA is the actual commit that is being built, set by the go linker's -X flag at build time.
+var GitSHA string

--- a/pkg/cmd/cli/backup/backup.go
+++ b/pkg/cmd/cli/backup/backup.go
@@ -33,6 +33,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 		NewCreateCommand(f),
 		NewGetCommand(f),
 		NewLogsCommand(f),
+		NewDownloadCommand(f),
 
 		// Will implement describe later
 		// NewDescribeCommand(f),

--- a/pkg/cmd/cli/backup/download.go
+++ b/pkg/cmd/cli/backup/download.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2017 Heptio Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/heptio/ark/pkg/apis/ark/v1"
+	"github.com/heptio/ark/pkg/client"
+	"github.com/heptio/ark/pkg/cmd"
+	"github.com/heptio/ark/pkg/cmd/util/downloadrequest"
+)
+
+func NewDownloadCommand(f client.Factory) *cobra.Command {
+	o := NewDownloadOptions()
+	c := &cobra.Command{
+		Use:   "download NAME",
+		Short: "Download a backup",
+		Run: func(c *cobra.Command, args []string) {
+			cmd.CheckError(o.Validate(c, args))
+			cmd.CheckError(o.Complete(args))
+			cmd.CheckError(o.Run(c, f))
+		},
+	}
+
+	o.BindFlags(c.Flags())
+
+	return c
+}
+
+type DownloadOptions struct {
+	Name         string
+	Path         string
+	Force        bool
+	Timeout      time.Duration
+	writeOptions int
+}
+
+func NewDownloadOptions() *DownloadOptions {
+	return &DownloadOptions{
+		Timeout: time.Minute,
+	}
+}
+
+func (o *DownloadOptions) BindFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&o.Path, "output-dir", "", "directory to download backup to. (Default cwd)")
+	flags.BoolVar(&o.Force, "force", o.Force, "forces the download and will overwrite file if it exists already")
+	flags.DurationVar(&o.Timeout, "timeout", o.Timeout, "maximum time to wait to process download request")
+}
+
+func (o *DownloadOptions) Validate(c *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return errors.New("backup name is required")
+	}
+
+	o.writeOptions = os.O_RDWR | os.O_CREATE | os.O_EXCL
+	if o.Force {
+		o.writeOptions = os.O_RDWR | os.O_CREATE | os.O_TRUNC
+	}
+
+	if o.Path == "" {
+		path, err := os.Getwd()
+		if err != nil {
+			return errors.New("an issue occurred attempting to determine the current working directory.")
+		}
+		o.Path = path
+	}
+
+	return nil
+}
+
+func (o *DownloadOptions) Complete(args []string) error {
+	o.Name = args[0]
+	return nil
+}
+
+func (o *DownloadOptions) Run(c *cobra.Command, f client.Factory) error {
+	arkClient, err := f.Client()
+	cmd.CheckError(err)
+
+	backupDest, err := os.OpenFile(path.Join(o.Path, fmt.Sprintf("%s-data.tar.gz", o.Name)), o.writeOptions, 0600)
+	if err != nil {
+		return err
+	}
+	defer backupDest.Close()
+
+	err = downloadrequest.Stream(arkClient.ArkV1(), o.Name, v1.DownloadTargetKindBackupContents, backupDest, o.Timeout)
+	cmd.CheckError(err)
+
+	fmt.Printf("Backup %s has been successfully downloaded to %s\n", o.Name, backupDest.Name())
+	return nil
+}

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -29,7 +29,7 @@ func NewCommand() *cobra.Command {
 		Use:   "version",
 		Short: "Print the ark version and associated image",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(buildinfo.Version)
+			fmt.Printf("Version: [%s] - [%s]\n", buildinfo.Version, buildinfo.GitSHA)
 			fmt.Println("Configured docker image:", buildinfo.DockerImage)
 		},
 	}

--- a/pkg/controller/download_request_controller.go
+++ b/pkg/controller/download_request_controller.go
@@ -216,13 +216,13 @@ const signedURLTTL = 10 * time.Minute
 // Processed, and persists the changes to storage.
 func (c *downloadRequestController) generatePreSignedURL(downloadRequest *v1.DownloadRequest) error {
 	switch downloadRequest.Spec.Target.Kind {
-	case v1.DownloadTargetKindBackupLog:
+	case v1.DownloadTargetKindBackupLog, v1.DownloadTargetKindBackupContents:
 		update, err := cloneDownloadRequest(downloadRequest)
 		if err != nil {
 			return err
 		}
 
-		update.Status.DownloadURL, err = c.backupService.CreateBackupLogSignedURL(c.bucket, update.Spec.Target.Name, signedURLTTL)
+		update.Status.DownloadURL, err = c.backupService.CreateBackupSignedURL(downloadRequest.Spec.Target.Kind, c.bucket, update.Spec.Target.Name, signedURLTTL)
 		if err != nil {
 			return err
 		}
@@ -233,8 +233,8 @@ func (c *downloadRequestController) generatePreSignedURL(downloadRequest *v1.Dow
 		_, err = c.downloadRequestClient.DownloadRequests(update.Namespace).Update(update)
 		return err
 	}
-
 	return fmt.Errorf("unsupported download target kind %q", downloadRequest.Spec.Target.Kind)
+
 }
 
 // deleteIfExpired deletes downloadRequest if it has expired.

--- a/pkg/util/test/backup_service.go
+++ b/pkg/util/test/backup_service.go
@@ -28,7 +28,7 @@ type BackupService struct {
 }
 
 // CreateBackupLogSignedURL provides a mock function with given fields: bucket, backupName, ttl
-func (_m *BackupService) CreateBackupLogSignedURL(bucket string, backupName string, ttl time.Duration) (string, error) {
+func (_m *BackupService) CreateBackupSignedURL(backupType v1.DownloadTargetKind, bucket string, backupName string, ttl time.Duration) (string, error) {
 	ret := _m.Called(bucket, backupName, ttl)
 
 	var r0 string


### PR DESCRIPTION
Fixes #16

NOTE: The original work has been rebased off of #40 which needs completion first. If it's preferable I can close this PR and create a net new one to keep the conversation more relevant

- Adding in support for a new `download` subcommand of backup
- Adjusted signing to allow for multiple types
- Adding in git sha version during build more granular version debugging
