### PR TITLE
Allows explicit include/exclude of namespaces on restores

### DIFF
--- a/docs/cli-reference/ark_restore_create.md
+++ b/docs/cli-reference/ark_restore_create.md
@@ -14,8 +14,8 @@ ark restore create BACKUP
 ### Options
 
 ```
-      --exclude-namespaces stringArray        namespaces to exclude from the backup
-      --include-namespaces stringArray        namespaces to include in the backup (use '*' for all namespaces) (default *)
+      --exclude-namespaces stringArray        namespaces to exclude from the restore
+      --include-namespaces stringArray        namespaces to include in the restore (use '*' for all namespaces) (default *)
       --label-columns stringArray             a comma-separated list of labels to be displayed as columns
       --labels mapStringString                labels to apply to the restore
       --namespace-mappings mapStringString    namespace mappings from name in the backup to desired restored name in the form src1:dst1,src2:dst2,...

--- a/docs/cli-reference/ark_restore_create.md
+++ b/docs/cli-reference/ark_restore_create.md
@@ -14,10 +14,11 @@ ark restore create BACKUP
 ### Options
 
 ```
+      --exclude-namespaces stringArray        namespaces to exclude from the backup
+      --include-namespaces stringArray        namespaces to include in the backup (use '*' for all namespaces) (default *)
       --label-columns stringArray             a comma-separated list of labels to be displayed as columns
       --labels mapStringString                labels to apply to the restore
       --namespace-mappings mapStringString    namespace mappings from name in the backup to desired restored name in the form src1:dst1,src2:dst2,...
-      --namespaces stringArray                comma-separated list of namespaces to restore
   -o, --output string                         Output display format. For create commands, display the object but do not send it to the server. Valid formats are 'table', 'json', and 'yaml'.
       --restore-volumes optionalBool[=true]   whether to restore volumes from snapshots
   -l, --selector labelSelector                only restore resources matching this label selector (default <none>)

--- a/pkg/apis/ark/v1/restore.go
+++ b/pkg/apis/ark/v1/restore.go
@@ -34,7 +34,7 @@ type RestoreSpec struct {
 	IncludedNamespaces []string `json:"includedNamespaces"`
 
 	// ExcludedNamespaces contains a list of namespaces that are not
-	// included in the backup.
+	// included in the restore.
 	ExcludedNamespaces []string `json:"excludedNamespaces"`
 
 	// NamespaceMapping is a map of source namespace names

--- a/pkg/apis/ark/v1/restore.go
+++ b/pkg/apis/ark/v1/restore.go
@@ -24,8 +24,18 @@ type RestoreSpec struct {
 	// from.
 	BackupName string `json:"backupName"`
 
+	// NOTE: This is deprecated.  IncludedNamespaces and ExcludedNamespaces
+	// should be used instead
 	// Namespaces is a slice of namespaces in the Ark backup to restore.
 	Namespaces []string `json:"namespaces"`
+
+	// IncludedNamespaces is a slice of namespace names to include objects
+	// from. If empty, all namespaces are included.
+	IncludedNamespaces []string `json:"includedNamespaces"`
+
+	// ExcludedNamespaces contains a list of namespaces that are not
+	// included in the backup.
+	ExcludedNamespaces []string `json:"excludedNamespaces"`
 
 	// NamespaceMapping is a map of source namespace names
 	// to target namespace names to restore into. Any source

--- a/pkg/apis/ark/v1/restore.go
+++ b/pkg/apis/ark/v1/restore.go
@@ -24,11 +24,6 @@ type RestoreSpec struct {
 	// from.
 	BackupName string `json:"backupName"`
 
-	// NOTE: This is deprecated.  IncludedNamespaces and ExcludedNamespaces
-	// should be used instead
-	// Namespaces is a slice of namespaces in the Ark backup to restore.
-	Namespaces []string `json:"namespaces"`
-
 	// IncludedNamespaces is a slice of namespace names to include objects
 	// from. If empty, all namespaces are included.
 	IncludedNamespaces []string `json:"includedNamespaces"`

--- a/pkg/cmd/cli/restore/create.go
+++ b/pkg/cmd/cli/restore/create.go
@@ -73,8 +73,8 @@ func NewCreateOptions() *CreateOptions {
 }
 
 func (o *CreateOptions) BindFlags(flags *pflag.FlagSet) {
-	flags.Var(&o.IncludeNamespaces, "include-namespaces", "namespaces to include in the backup (use '*' for all namespaces)")
-	flags.Var(&o.ExcludeNamespaces, "exclude-namespaces", "namespaces to exclude from the backup")
+	flags.Var(&o.IncludeNamespaces, "include-namespaces", "namespaces to include in the restore (use '*' for all namespaces)")
+	flags.Var(&o.ExcludeNamespaces, "exclude-namespaces", "namespaces to exclude from the restore")
 	flags.Var(&o.NamespaceMappings, "namespace-mappings", "namespace mappings from name in the backup to desired restored name in the form src1:dst1,src2:dst2,...")
 	flags.Var(&o.Labels, "labels", "labels to apply to the restore")
 	flags.VarP(&o.Selector, "selector", "l", "only restore resources matching this label selector")

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -292,11 +292,11 @@ func cloneBackup(in interface{}) (*api.Backup, error) {
 func (controller *backupController) getValidationErrors(itm *api.Backup) []string {
 	var validationErrors []string
 
-	for err := range collections.ValidateIncludesExcludes(itm.Spec.IncludedResources, itm.Spec.ExcludedResources) {
+	for _, err := range collections.ValidateIncludesExcludes(itm.Spec.IncludedResources, itm.Spec.ExcludedResources) {
 		validationErrors = append(validationErrors, fmt.Sprintf("Invalid included/excluded resource lists: %v", err))
 	}
 
-	for err := range collections.ValidateIncludesExcludes(itm.Spec.IncludedNamespaces, itm.Spec.ExcludedNamespaces) {
+	for _, err := range collections.ValidateIncludesExcludes(itm.Spec.IncludedNamespaces, itm.Spec.ExcludedNamespaces) {
 		validationErrors = append(validationErrors, fmt.Sprintf("Invalid included/excluded namespace lists: %v", err))
 	}
 

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -39,6 +39,7 @@ import (
 	informers "github.com/heptio/ark/pkg/generated/informers/externalversions/ark/v1"
 	listers "github.com/heptio/ark/pkg/generated/listers/ark/v1"
 	"github.com/heptio/ark/pkg/restore"
+	"github.com/heptio/ark/pkg/util/collections"
 )
 
 type restoreController struct {
@@ -286,7 +287,11 @@ func (controller *restoreController) getValidationErrors(itm *api.Restore) []str
 	}
 
 	if len(itm.Spec.Namespaces) > 0 && len(itm.Spec.IncludedNamespaces) > 0 {
-		validationErrors = append(validationErrors, "Namespace and ItemNamespaces can not both be defined on the backup spec.")
+		validationErrors = append(validationErrors, "Namespaces and IncludedNamespaces can not both be defined on the backup spec.")
+	}
+
+	for err := range collections.ValidateIncludesExcludes(itm.Spec.IncludedNamespaces, itm.Spec.ExcludedNamespaces) {
+		validationErrors = append(validationErrors, fmt.Sprintf("Invalid included/excluded namespace lists: %v", err))
 	}
 
 	if !controller.pvProviderExists && itm.Spec.RestorePVs != nil && *itm.Spec.RestorePVs {

--- a/pkg/controller/restore_controller_test.go
+++ b/pkg/controller/restore_controller_test.go
@@ -73,16 +73,16 @@ func TestProcessRestore(t *testing.T) {
 			expectedErr: false,
 		},
 		{
-			name:        "restore with both namespaces and includedNamespaces fails validation",
-			restore:     NewTestRestore("foo", "bar", api.RestorePhaseNew).WithBackup("backup-1").WithNamespace("ns-1").WithIncludedNamespace("another-1").Restore,
+			name:        "restore with both namespace in both includedNamespaces and excludedNamespaces fails validation",
+			restore:     NewTestRestore("foo", "bar", api.RestorePhaseNew).WithBackup("backup-1").WithIncludedNamespace("another-1").WithExcludedNamespace("another-1").Restore,
 			backup:      NewTestBackup().WithName("backup-1").Backup,
 			expectedErr: false,
 			expectedRestoreUpdates: []*api.Restore{
 				NewTestRestore("foo", "bar", api.RestorePhaseFailedValidation).
 					WithBackup("backup-1").
-					WithNamespace("ns-1").
 					WithIncludedNamespace("another-1").
-					WithValidationError("Namespace and ItemNamespaces can not both be defined on the backup spec.").Restore,
+					WithExcludedNamespace("another-1").
+					WithValidationError("Invalid included/excluded namespace lists: excludes list cannot contain an item in the includes list: another-1").Restore,
 			},
 		},
 		{

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -102,15 +102,36 @@ func TestRestoreMethod(t *testing.T) {
 			name:             "namespacesToRestore having * restores all namespaces",
 			fileSystem:       newFakeFileSystem().WithDirectories("bak/cluster", "bak/namespaces/a", "bak/namespaces/b", "bak/namespaces/c"),
 			baseDir:          "bak",
-			restore:          &api.Restore{Spec: api.RestoreSpec{Namespaces: []string{"*"}}},
+			restore:          &api.Restore{Spec: api.RestoreSpec{IncludedNamespaces: []string{"*"}}},
 			expectedReadDirs: []string{"bak/cluster", "bak/namespaces", "bak/namespaces/a", "bak/namespaces/b", "bak/namespaces/c"},
 		},
 		{
 			name:             "namespacesToRestore properly filters",
 			fileSystem:       newFakeFileSystem().WithDirectories("bak/cluster", "bak/namespaces/a", "bak/namespaces/b", "bak/namespaces/c"),
 			baseDir:          "bak",
-			restore:          &api.Restore{Spec: api.RestoreSpec{Namespaces: []string{"b", "c"}}},
+			restore:          &api.Restore{Spec: api.RestoreSpec{IncludedNamespaces: []string{"b", "c"}}},
 			expectedReadDirs: []string{"bak/cluster", "bak/namespaces", "bak/namespaces/b", "bak/namespaces/c"},
+		},
+		{
+			name:             "namespacesToRestore properly filters with inclusion filter",
+			fileSystem:       newFakeFileSystem().WithDirectories("bak/cluster", "bak/namespaces/a", "bak/namespaces/b", "bak/namespaces/c"),
+			baseDir:          "bak",
+			restore:          &api.Restore{Spec: api.RestoreSpec{IncludedNamespaces: []string{"b", "c"}}},
+			expectedReadDirs: []string{"bak/cluster", "bak/namespaces", "bak/namespaces/b", "bak/namespaces/c"},
+		},
+		{
+			name:             "namespacesToRestore properly filters with exclusion filter",
+			fileSystem:       newFakeFileSystem().WithDirectories("bak/cluster", "bak/namespaces/a", "bak/namespaces/b", "bak/namespaces/c"),
+			baseDir:          "bak",
+			restore:          &api.Restore{Spec: api.RestoreSpec{IncludedNamespaces: []string{"*"}, ExcludedNamespaces: []string{"a"}}},
+			expectedReadDirs: []string{"bak/cluster", "bak/namespaces", "bak/namespaces/b", "bak/namespaces/c"},
+		},
+		{
+			name:             "namespacesToRestore properly filters with inclusion & exclusion filters",
+			fileSystem:       newFakeFileSystem().WithDirectories("bak/cluster", "bak/namespaces/a", "bak/namespaces/b", "bak/namespaces/c"),
+			baseDir:          "bak",
+			restore:          &api.Restore{Spec: api.RestoreSpec{IncludedNamespaces: []string{"a", "b", "c"}, ExcludedNamespaces: []string{"b"}}},
+			expectedReadDirs: []string{"bak/cluster", "bak/namespaces", "bak/namespaces/a", "bak/namespaces/c"},
 		},
 	}
 

--- a/pkg/restore/restorers/namespace_restorer.go
+++ b/pkg/restore/restorers/namespace_restorer.go
@@ -37,13 +37,10 @@ func (nsr *namespaceRestorer) Handles(obj runtime.Unstructured, restore *api.Res
 		return false
 	}
 
-	for _, restorableNS := range restore.Spec.Namespaces {
-		if restorableNS == nsName {
-			return true
-		}
-	}
-
-	return false
+	return collections.NewIncludesExcludes().
+		Includes(restore.Spec.IncludedNamespaces...).
+		Excludes(restore.Spec.ExcludedNamespaces...).
+		ShouldInclude(nsName)
 }
 
 func (nsr *namespaceRestorer) Prepare(obj runtime.Unstructured, restore *api.Restore, backup *api.Backup) (runtime.Unstructured, error, error) {

--- a/pkg/restore/restorers/namespace_restorer_test.go
+++ b/pkg/restore/restorers/namespace_restorer_test.go
@@ -37,19 +37,31 @@ func TestHandles(t *testing.T) {
 		{
 			name:    "restorable NS",
 			obj:     NewTestUnstructured().WithName("ns-1").Unstructured,
-			restore: testutil.NewDefaultTestRestore().WithRestorableNamespace("ns-1").Restore,
+			restore: testutil.NewDefaultTestRestore().WithIncludedNamespace("ns-1").Restore,
+			expect:  true,
+		},
+		{
+			name:    "restorable NS via wildcard",
+			obj:     NewTestUnstructured().WithName("ns-1").Unstructured,
+			restore: testutil.NewDefaultTestRestore().WithIncludedNamespace("*").Restore,
 			expect:  true,
 		},
 		{
 			name:    "non-restorable NS",
 			obj:     NewTestUnstructured().WithName("ns-1").Unstructured,
-			restore: testutil.NewDefaultTestRestore().WithRestorableNamespace("ns-2").Restore,
+			restore: testutil.NewDefaultTestRestore().WithIncludedNamespace("ns-2").Restore,
+			expect:  false,
+		},
+		{
+			name:    "namespace is explicitly excluded",
+			obj:     NewTestUnstructured().WithName("ns-1").Unstructured,
+			restore: testutil.NewDefaultTestRestore().WithIncludedNamespace("*").WithExcludedNamespace("ns-1").Restore,
 			expect:  false,
 		},
 		{
 			name:    "namespace obj doesn't have name",
 			obj:     NewTestUnstructured().WithMetadata().Unstructured,
-			restore: testutil.NewDefaultTestRestore().WithRestorableNamespace("ns-1").Restore,
+			restore: testutil.NewDefaultTestRestore().WithIncludedNamespace("ns-1").Restore,
 			expect:  false,
 		},
 	}

--- a/pkg/util/test/test_restore.go
+++ b/pkg/util/test/test_restore.go
@@ -45,12 +45,6 @@ func NewDefaultTestRestore() *TestRestore {
 	return NewTestRestore(api.DefaultNamespace, "", api.RestorePhase(""))
 }
 
-
-func (r *TestRestore) WithNamespace(name string) *TestRestore {
-	r.Spec.Namespaces = append(r.Spec.Namespaces, name)
-	return r
-}
-
 func (r *TestRestore) WithIncludedNamespace(name string) *TestRestore {
 	r.Spec.IncludedNamespaces = append(r.Spec.IncludedNamespaces, name)
 	return r

--- a/pkg/util/test/test_restore.go
+++ b/pkg/util/test/test_restore.go
@@ -45,8 +45,19 @@ func NewDefaultTestRestore() *TestRestore {
 	return NewTestRestore(api.DefaultNamespace, "", api.RestorePhase(""))
 }
 
-func (r *TestRestore) WithRestorableNamespace(name string) *TestRestore {
+
+func (r *TestRestore) WithNamespace(name string) *TestRestore {
 	r.Spec.Namespaces = append(r.Spec.Namespaces, name)
+	return r
+}
+
+func (r *TestRestore) WithIncludedNamespace(name string) *TestRestore {
+	r.Spec.IncludedNamespaces = append(r.Spec.IncludedNamespaces, name)
+	return r
+}
+
+func (r *TestRestore) WithExcludedNamespace(name string) *TestRestore {
+	r.Spec.ExcludedNamespaces = append(r.Spec.ExcludedNamespaces, name)
 	return r
 }
 


### PR DESCRIPTION
Fixes #22

- Introduces similar Include/Exclude declaration on the Restore
resource and cli flags
- Removed the Namespace attribute
- Fixed a few small issues with the backup validation

Signed-off-by: Justin Nauman <justin.r.nauman@gmail.com>