### PR TITLE
Allow default kubeconfig resolution

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -24,8 +24,11 @@ import (
 // Config returns a *rest.Config, using either the kubeconfig (if specified) or an in-cluster
 // configuration.
 func Config(kubeconfig string) (*rest.Config, error) {
-	if len(kubeconfig) > 0 {
-		return clientcmd.BuildConfigFromFlags("", kubeconfig)
+	loader := clientcmd.NewDefaultClientConfigLoadingRules()
+	loader.ExplicitPath = kubeconfig
+	clientConfig, err := clientcmd.BuildConfigFromKubeconfigGetter("", loader.Load)
+	if err != nil {
+		return nil, err
 	}
-	return rest.InClusterConfig()
+	return clientConfig, nil
 }

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -17,8 +17,6 @@ limitations under the License.
 package client
 
 import (
-	"os"
-
 	"github.com/spf13/pflag"
 
 	"github.com/heptio/ark/pkg/generated/clientset"
@@ -53,13 +51,7 @@ func (f *factory) BindFlags(flags *pflag.FlagSet) {
 }
 
 func (f *factory) Client() (clientset.Interface, error) {
-	kubeconfig := f.kubeconfig
-	if kubeconfig == "" {
-		// if the command line flag was not specified, try the environment variable
-		kubeconfig = os.Getenv("KUBECONFIG")
-	}
-
-	clientConfig, err := Config(kubeconfig)
+	clientConfig, err := Config(f.kubeconfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Changed the default kubeconfig loading to utilize
the client-go's loader strategy.  This allows users
to use the Ark client without having to explicitly
define a KUBECONFIG env var or argument.

This more closely resemebles how Kubectl works and users
are probably more used to while preserving the
current rules.

Signed-off-by: Justin Nauman <justin.r.nauman@gmail.com>