### PR TITLE
Add per-restore logs

### DIFF
--- a/docs/cli-reference/ark_backup_download.md
+++ b/docs/cli-reference/ark_backup_download.md
@@ -14,10 +14,10 @@ ark backup download NAME [flags]
 ### Options
 
 ```
-      --force               forces the download and will overwrite file if it exists already
-  -h, --help                help for download
-      --output-dir string   directory to download backup to. (Default cwd)
-      --timeout duration    maximum time to wait to process download request (default 1m0s)
+      --force              forces the download and will overwrite file if it exists already
+  -h, --help               help for download
+  -o, --output string      path to output file. Defaults to <NAME>-data.tar.gz in the current directory
+      --timeout duration   maximum time to wait to process download request (default 1m0s)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/ark_restore_logs.md
+++ b/docs/cli-reference/ark_restore_logs.md
@@ -1,16 +1,21 @@
-## ark restore
+## ark restore logs
 
-Work with restores
+Get restore logs
 
 ### Synopsis
 
 
-Work with restores
+Get restore logs
+
+```
+ark restore logs RESTORE [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for restore
+  -h, --help               help for logs
+      --timeout duration   how long to wait to receive logs (default 1m0s)
 ```
 
 ### Options inherited from parent commands
@@ -27,9 +32,5 @@ Work with restores
 ```
 
 ### SEE ALSO
-* [ark](ark.md)	 - Back up and restore Kubernetes cluster resources.
-* [ark restore create](ark_restore_create.md)	 - Create a restore
-* [ark restore delete](ark_restore_delete.md)	 - Delete a restore
-* [ark restore get](ark_restore_get.md)	 - get restores
-* [ark restore logs](ark_restore_logs.md)	 - Get restore logs
+* [ark restore](ark_restore.md)	 - Work with restores
 

--- a/pkg/apis/ark/v1/download_request.go
+++ b/pkg/apis/ark/v1/download_request.go
@@ -30,6 +30,7 @@ type DownloadTargetKind string
 const (
 	DownloadTargetKindBackupLog      DownloadTargetKind = "BackupLog"
 	DownloadTargetKindBackupContents DownloadTargetKind = "BackupContents"
+	DownloadTargetKindRestoreLog     DownloadTargetKind = "RestoreLog"
 )
 
 // DownloadTarget is the specification for what kind of file to download, and the name of the

--- a/pkg/cloudprovider/aws/block_storage_adapter.go
+++ b/pkg/cloudprovider/aws/block_storage_adapter.go
@@ -167,7 +167,7 @@ func (op *blockStorageAdapter) ListSnapshots(tagFilters map[string]string) ([]st
 	}
 
 	var ret []string
-	err := op.ec2.DescribeSnapshotsPages(req, func (res *ec2.DescribeSnapshotsOutput, lastPage bool) bool {
+	err := op.ec2.DescribeSnapshotsPages(req, func(res *ec2.DescribeSnapshotsOutput, lastPage bool) bool {
 		for _, snapshot := range res.Snapshots {
 			ret = append(ret, *snapshot.SnapshotId)
 		}

--- a/pkg/cloudprovider/backup_service.go
+++ b/pkg/cloudprovider/backup_service.go
@@ -68,8 +68,8 @@ type BackupGetter interface {
 
 const (
 	metadataFileFormatString   = "%s/ark-backup.json"
-	backupFileFormatString     = "%s/%s-data.tar.gz"
-	backukpLogFileFormatString = "%s/%s-logs.gz"
+	backupFileFormatString     = "%s/%s.tar.gz"
+	backupLogFileFormatString  = "%s/%s-logs.gz"
 	restoreLogFileFormatString = "%s/restore-%s-logs.gz"
 )
 
@@ -82,7 +82,7 @@ func getBackupContentsKey(backup string) string {
 }
 
 func getBackupLogKey(backup string) string {
-	return fmt.Sprintf(backukpLogFileFormatString, backup, backup)
+	return fmt.Sprintf(backupLogFileFormatString, backup, backup)
 }
 
 func getRestoreLogKey(backup, restore string) string {

--- a/pkg/cloudprovider/backup_service_test.go
+++ b/pkg/cloudprovider/backup_service_test.go
@@ -88,7 +88,7 @@ func TestUploadBackup(t *testing.T) {
 				objStore.On("PutObject", bucket, backupName+"/ark-backup.json", test.metadata).Return(test.metadataError)
 			}
 			if test.backup != nil {
-				objStore.On("PutObject", bucket, backupName+"/"+backupName+"-data.tar.gz", test.backup).Return(test.backupError)
+				objStore.On("PutObject", bucket, backupName+"/"+backupName+".tar.gz", test.backup).Return(test.backupError)
 			}
 			if test.log != nil {
 				objStore.On("PutObject", bucket, backupName+"/"+backupName+"-logs.gz", test.log).Return(test.logError)
@@ -116,7 +116,7 @@ func TestDownloadBackup(t *testing.T) {
 	o := &testutil.ObjectStorageAdapter{}
 	bucket := "b"
 	backup := "bak"
-	o.On("GetObject", bucket, backup+"/"+backup+"-data.tar.gz").Return(ioutil.NopCloser(strings.NewReader("foo")), nil)
+	o.On("GetObject", bucket, backup+"/"+backup+".tar.gz").Return(ioutil.NopCloser(strings.NewReader("foo")), nil)
 	s := NewBackupService(o)
 	rc, err := s.DownloadBackup(bucket, backup)
 	require.NoError(t, err)

--- a/pkg/cmd/cli/restore/logs.go
+++ b/pkg/cmd/cli/restore/logs.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2017 Heptio Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restore
+
+import (
+	"errors"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/heptio/ark/pkg/apis/ark/v1"
+	"github.com/heptio/ark/pkg/client"
+	"github.com/heptio/ark/pkg/cmd"
+	"github.com/heptio/ark/pkg/cmd/util/downloadrequest"
+)
+
+func NewLogsCommand(f client.Factory) *cobra.Command {
+	timeout := time.Minute
+
+	c := &cobra.Command{
+		Use:   "logs RESTORE",
+		Short: "Get restore logs",
+		Run: func(c *cobra.Command, args []string) {
+			if len(args) != 1 {
+				err := errors.New("restore name is required")
+				cmd.CheckError(err)
+			}
+
+			arkClient, err := f.Client()
+			cmd.CheckError(err)
+
+			err = downloadrequest.Stream(arkClient.ArkV1(), args[0], v1.DownloadTargetKindRestoreLog, os.Stdout, timeout)
+			cmd.CheckError(err)
+		},
+	}
+
+	c.Flags().DurationVar(&timeout, "timeout", timeout, "how long to wait to receive logs")
+
+	return c
+}

--- a/pkg/cmd/cli/restore/restore.go
+++ b/pkg/cmd/cli/restore/restore.go
@@ -32,6 +32,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 	c.AddCommand(
 		NewCreateCommand(f),
 		NewGetCommand(f),
+		NewLogsCommand(f),
 		// Will implement later
 		// NewDescribeCommand(f),
 		NewDeleteCommand(f),

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -492,7 +492,6 @@ func (s *server) runControllers(config *api.Config) error {
 	downloadRequestController := controller.NewDownloadRequestController(
 		s.arkClient.ArkV1(),
 		s.sharedInformerFactory.Ark().V1().DownloadRequests(),
-		s.sharedInformerFactory.Ark().V1().Backups(),
 		s.backupService,
 		config.BackupStorageProvider.Bucket,
 	)

--- a/pkg/cmd/util/downloadrequest/downloadrequest.go
+++ b/pkg/cmd/util/downloadrequest/downloadrequest.go
@@ -124,12 +124,17 @@ Loop:
 		return fmt.Errorf("request failed: %v", string(body))
 	}
 
-	gzipReader, err := gzip.NewReader(resp.Body)
-	if err != nil {
-		return err
+	reader := resp.Body
+	if kind != v1.DownloadTargetKindBackupContents {
+		// need to decompress logs
+		gzipReader, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return err
+		}
+		defer gzipReader.Close()
+		reader = gzipReader
 	}
-	defer gzipReader.Close()
 
-	_, err = io.Copy(w, gzipReader)
+	_, err = io.Copy(w, reader)
 	return err
 }

--- a/pkg/controller/download_request_controller_test.go
+++ b/pkg/controller/download_request_controller_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2017 Heptio Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	core "k8s.io/client-go/testing"
+
+	"github.com/heptio/ark/pkg/apis/ark/v1"
+	"github.com/heptio/ark/pkg/generated/clientset/fake"
+	informers "github.com/heptio/ark/pkg/generated/informers/externalversions"
+	"github.com/heptio/ark/pkg/util/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessDownloadRequest(t *testing.T) {
+	tests := []struct {
+		name          string
+		key           string
+		phase         v1.DownloadRequestPhase
+		targetKind    v1.DownloadTargetKind
+		targetName    string
+		expectedError string
+		expectedPhase v1.DownloadRequestPhase
+		expectedURL   string
+	}{
+		{
+			name: "empty key",
+			key:  "",
+		},
+		{
+			name:          "bad key format",
+			key:           "a/b/c",
+			expectedError: `unexpected key format: "a/b/c"`,
+		},
+		{
+			name:          "backup log request with phase '' gets a url",
+			key:           "heptio-ark/dr1",
+			phase:         "",
+			targetKind:    v1.DownloadTargetKindBackupLog,
+			targetName:    "backup1",
+			expectedPhase: v1.DownloadRequestPhaseProcessed,
+			expectedURL:   "signedURL",
+		},
+		{
+			name:          "backup log request with phase 'New' gets a url",
+			key:           "heptio-ark/dr1",
+			phase:         v1.DownloadRequestPhaseNew,
+			targetKind:    v1.DownloadTargetKindBackupLog,
+			targetName:    "backup1",
+			expectedPhase: v1.DownloadRequestPhaseProcessed,
+			expectedURL:   "signedURL",
+		},
+		{
+			name:          "restore log request with phase '' gets a url",
+			key:           "heptio-ark/dr1",
+			phase:         "",
+			targetKind:    v1.DownloadTargetKindRestoreLog,
+			targetName:    "backup1-20170912150214",
+			expectedPhase: v1.DownloadRequestPhaseProcessed,
+			expectedURL:   "signedURL",
+		},
+		{
+			name:          "restore log request with phase New gets a url",
+			key:           "heptio-ark/dr1",
+			phase:         v1.DownloadRequestPhaseNew,
+			targetKind:    v1.DownloadTargetKindRestoreLog,
+			targetName:    "backup1-20170912150214",
+			expectedPhase: v1.DownloadRequestPhaseProcessed,
+			expectedURL:   "signedURL",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset()
+			sharedInformers := informers.NewSharedInformerFactory(client, 0)
+			downloadRequestsInformer := sharedInformers.Ark().V1().DownloadRequests()
+			backupService := &test.BackupService{}
+			defer backupService.AssertExpectations(t)
+
+			c := NewDownloadRequestController(
+				client.ArkV1(),
+				downloadRequestsInformer,
+				backupService,
+				"bucket",
+			).(*downloadRequestController)
+
+			if tc.expectedPhase == v1.DownloadRequestPhaseProcessed {
+				target := v1.DownloadTarget{
+					Kind: tc.targetKind,
+					Name: tc.targetName,
+				}
+
+				downloadRequestsInformer.Informer().GetStore().Add(
+					&v1.DownloadRequest{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: v1.DefaultNamespace,
+							Name:      "dr1",
+						},
+						Spec: v1.DownloadRequestSpec{
+							Target: target,
+						},
+					},
+				)
+
+				backupService.On("CreateSignedURL", target, "bucket", 10*time.Minute).Return("signedURL", nil)
+			}
+
+			var updatedRequest *v1.DownloadRequest
+
+			client.PrependReactor("update", "downloadrequests", func(action core.Action) (bool, runtime.Object, error) {
+				obj := action.(core.UpdateAction).GetObject()
+				r, ok := obj.(*v1.DownloadRequest)
+				require.True(t, ok)
+				updatedRequest = r
+				return true, obj, nil
+			})
+
+			// method under test
+			err := c.processDownloadRequest(tc.key)
+
+			if tc.expectedError != "" {
+				assert.EqualError(t, err, tc.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+
+			var (
+				updatedPhase v1.DownloadRequestPhase
+				updatedURL   string
+			)
+			if updatedRequest != nil {
+				updatedPhase = updatedRequest.Status.Phase
+				updatedURL = updatedRequest.Status.DownloadURL
+			}
+			assert.Equal(t, tc.expectedPhase, updatedPhase)
+			assert.Equal(t, tc.expectedURL, updatedURL)
+		})
+	}
+}

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -451,22 +451,22 @@ func (ctx *context) restoreResourceForNamespace(namespace string, resourcePath s
 			var err error
 			resourceClient, err = ctx.dynamicFactory.ClientForGroupVersionKind(obj.GroupVersionKind(), resource, namespace)
 			if err != nil {
-				addArkError(&errors, fmt.Errorf("error getting resource client for namespace %q, resource %q: %v", namespace, groupResource, err))
+				addArkError(&errors, fmt.Errorf("error getting resource client for namespace %q, resource %q: %v", namespace, &groupResource, err))
 				return warnings, errors
 			}
 
 			restorer = ctx.restorers[groupResource]
 			if restorer == nil {
-				ctx.log("Using default restorer for %v", groupResource)
+				ctx.log("Using default restorer for %v", &groupResource)
 				restorer = restorers.NewBasicRestorer(true)
 			} else {
-				ctx.log("Using custom restorer for %v", groupResource)
+				ctx.log("Using custom restorer for %v", &groupResource)
 			}
 
 			if restorer.Wait() {
 				itmWatch, err := resourceClient.Watch(metav1.ListOptions{})
 				if err != nil {
-					addArkError(&errors, fmt.Errorf("error watching for namespace %q, resource %q: %v", namespace, groupResource, err))
+					addArkError(&errors, fmt.Errorf("error watching for namespace %q, resource %q: %v", namespace, &groupResource, err))
 					return warnings, errors
 				}
 				watchChan := itmWatch.ResultChan()
@@ -525,7 +525,7 @@ func (ctx *context) restoreResourceForNamespace(namespace string, resourcePath s
 
 	if waiter != nil {
 		if err := waiter.Wait(); err != nil {
-			addArkError(&errors, fmt.Errorf("error waiting for all %v resources to be created in namespace %s: %v", groupResource, namespace, err))
+			addArkError(&errors, fmt.Errorf("error waiting for all %v resources to be created in namespace %s: %v", &groupResource, namespace, err))
 		}
 	}
 

--- a/pkg/util/test/backup_service.go
+++ b/pkg/util/test/backup_service.go
@@ -27,20 +27,20 @@ type BackupService struct {
 	mock.Mock
 }
 
-// CreateBackupLogSignedURL provides a mock function with given fields: bucket, backupName, ttl
-func (_m *BackupService) CreateBackupSignedURL(backupType v1.DownloadTargetKind, bucket string, backupName string, ttl time.Duration) (string, error) {
-	ret := _m.Called(bucket, backupName, ttl)
+// CreateSignedURL provides a mock function with given fields: target, bucket, ttl
+func (_m *BackupService) CreateSignedURL(target v1.DownloadTarget, bucket string, ttl time.Duration) (string, error) {
+	ret := _m.Called(target, bucket, ttl)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(string, string, time.Duration) string); ok {
-		r0 = rf(bucket, backupName, ttl)
+	if rf, ok := ret.Get(0).(func(v1.DownloadTarget, string, time.Duration) string); ok {
+		r0 = rf(target, bucket, ttl)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, time.Duration) error); ok {
-		r1 = rf(bucket, backupName, ttl)
+	if rf, ok := ret.Get(1).(func(v1.DownloadTarget, string, time.Duration) error); ok {
+		r1 = rf(target, bucket, ttl)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -138,6 +138,20 @@ func (_m *BackupService) UploadBackup(bucket string, name string, metadata io.Re
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, string, io.ReadSeeker, io.ReadSeeker, io.ReadSeeker) error); ok {
 		r0 = rf(bucket, name, metadata, backup, log)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// UploadRestoreLog provides a mock function with given fields: bucket, backup, restore, log
+func (_m *BackupService) UploadRestoreLog(bucket string, backup string, restore string, log io.ReadSeeker) error {
+	ret := _m.Called(bucket, backup, restore, log)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, string, io.ReadSeeker) error); ok {
+		r0 = rf(bucket, backup, restore, log)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/util/test/fake_discovery_helper.go
+++ b/pkg/util/test/fake_discovery_helper.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 Heptio Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package test
 
 import (


### PR DESCRIPTION
Add per-restore logs. Also have a few other changes:
- don't unzip backup data during `ark backup download` so that what is written to disk is actually gzip-compressed tar data (before, it was getting uncompressed on the fly and being saved as just a tar)
- have the user specify the output file when downloading a backup instead of the containing dir
- fix printing of schema.GroupResources from #78 

cc @jrnt30 