### PR TITLE
Tweak version display

### DIFF
--- a/pkg/buildinfo/version.go
+++ b/pkg/buildinfo/version.go
@@ -14,17 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package buildinfo holds build-time information like the sonobuoy version.
+// Package buildinfo holds build-time information like the ark version.
 // This is a separate package so that other packages can import it without
 // worrying about introducing circular dependencies.
 package buildinfo
 
-// Version is the current version of Ark, set by the go linker's -X flag at build time.
-var Version string
+var (
+	// Version is the current version of Ark, set by the go linker's -X flag at build time.
+	Version string
 
-// DockerImage is the full path to the docker image for this build, for example
-// gcr.io/heptio-images/ark.
-var DockerImage string
+	// DockerImage is the full path to the docker image for this build, for example
+	// gcr.io/heptio-images/ark.
+	DockerImage string
 
-// GitSHA is the actual commit that is being built, set by the go linker's -X flag at build time.
-var GitSHA string
+	// GitSHA is the actual commit that is being built, set by the go linker's -X flag at build time.
+	GitSHA string
+
+	// GitTreeState indicates if the git tree is clean or dirty, set by the go linker's -X flag at build
+	// time.
+	GitTreeState string
+)

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -29,7 +29,9 @@ func NewCommand() *cobra.Command {
 		Use:   "version",
 		Short: "Print the ark version and associated image",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Version: [%s] - [%s]\n", buildinfo.Version, buildinfo.GitSHA)
+			fmt.Printf("Version: %s\n", buildinfo.Version)
+			fmt.Printf("Git commit: %s\n", buildinfo.GitSHA)
+			fmt.Printf("Git tree state: %s\n", buildinfo.GitTreeState)
 			fmt.Println("Configured docker image:", buildinfo.DockerImage)
 		},
 	}


### PR DESCRIPTION
Now displayed as:
```
$ ark version
Version: v0.3.3
Git commit: 81fda27
Git tree state: clean
Configured docker image: gcr.io/heptio-images/ark
```

@skriss @jrnt30 WDYT?

Signed-off-by: Andy Goldstein <andy.goldstein@gmail.com>