### PR TITLE
change Azure API timeout default to 2m

### DIFF
--- a/docs/config-definition.md
+++ b/docs/config-definition.md
@@ -99,7 +99,7 @@ No parameters required; specify an empty object per [example file][14].
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `location` | string | Required Field | *Example*: "Canada East"<br><br>See [the list of available locations][7] (note that this particular page refers to them as "Regions"). |
-| `apiTimeout` | metav1.Duration | 1m0s | How long to wait for an API Azure request to complete before timeout. |
+| `apiTimeout` | metav1.Duration | 2m0s | How long to wait for an Azure API request to complete before timeout. |
 
 [0]: #aws
 [1]: #gcp

--- a/pkg/cloudprovider/azure/block_storage_adapter.go
+++ b/pkg/cloudprovider/azure/block_storage_adapter.go
@@ -78,7 +78,7 @@ func NewBlockStorageAdapter(location string, apiTimeout time.Duration) (cloudpro
 	}
 
 	if apiTimeout == 0 {
-		apiTimeout = time.Minute
+		apiTimeout = 2 * time.Minute
 	}
 
 	cfg := getConfig()


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

@ncdc let's get this in 0.4 if you're OK with it. Seems like the API calls often take just over a minute. Our sample config already has 2m as the pre-filled value.