### PR TITLE
README: Mention Ark Slack channel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Looking at a specific example--an `ark backup create test-backup` command trigge
 
 ## Troubleshooting
 
-If you encounter any problems that the documentation does not address, [file an issue][4].  
+If you encounter any problems that the documentation does not address, [file an issue][4] or talk to us on the [Kubernetes Slack team][25] channel `#ark-dr`.
 
 ## Contributing
 
@@ -211,3 +211,4 @@ See [the list of releases][6] to find out about feature changes.
 [22]: https://github.com/coreos/etcd
 [23]: /docs/cloud-provider-specifics.md
 [24]: http://j.hept.io/ark-list
+[25]: http://slack.kubernetes.io/


### PR DESCRIPTION
Here's a quick PR to add a reference in the README file to Ark's Slack channel ([as suggested on Twitter](https://twitter.com/timoreimann/status/910625727682408454)).

Let me know if putting the node under the Troubleshooting section is okay or whether you'd rather see it structured differently.

/cc @ncdc @jbeda 