### PR TITLE
Restructure backup format for resource prioritization

### DIFF
--- a/docs/output-file-format.md
+++ b/docs/output-file-format.md
@@ -62,26 +62,38 @@ Note that this file includes detailed info about your volume snapshots in the `s
 When unzipped, a typical backup directory (e.g. `backup1234.tar.gz`) looks like the following:
 
 ```
-cluster/
+resources/
     persistentvolumes/
-        pv01.json
-        ...
-namespaces/
-    namespace1/
-        configmaps/
-            myconfigmap.json
+        cluster/
+            pv01.json
             ...
-        pods
-            mypod.json
-            ...
-        jobs
-            awesome-job.json
-            ...
-        deployments
-            cool-deployment.json
-            ...
-        ...
-    namespace2/
-        ...
+    configmaps/
+        namespaces/
+            namespace1/
+                myconfigmap.json
+                ...
+            namespace2/
+                ...
+    pods/
+        namespaces/
+            namespace1/
+                mypod.json
+                ...
+            namespace2/
+                ...
+    jobs/
+        namespaces/
+            namespace1/
+                awesome-job.json
+                ...
+            namespace2/
+                ...
+    deployments/
+        namespaces/
+            namespace1/
+                cool-deployment.json
+                ...
+            namespace2/
+                ...
     ...
 ```

--- a/pkg/apis/ark/v1/constants.go
+++ b/pkg/apis/ark/v1/constants.go
@@ -21,6 +21,10 @@ const (
 	// the Ark server and API objects.
 	DefaultNamespace = "heptio-ark"
 
+	// ResourcesDir is a top-level directory expected in backups which contains sub-directories
+	// for each resource type in the backup.
+	ResourcesDir = "resources"
+
 	// RestoreLabelKey is the label key that's applied to all resources that
 	// are created during a restore. This is applied for ease of identification
 	// of restored resources. The value will be the restore's name.

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -473,9 +474,9 @@ func (ib *realItemBackupper) backupItem(ctx *backupContext, item map[string]inte
 
 	var filePath string
 	if namespace != "" {
-		filePath = strings.Join([]string{api.NamespaceScopedDir, namespace, groupResource.String(), name + ".json"}, "/")
+		filePath = filepath.Join(api.ResourcesDir, groupResource.String(), api.NamespaceScopedDir, namespace, name+".json")
 	} else {
-		filePath = strings.Join([]string{api.ClusterScopedDir, groupResource.String(), name + ".json"}, "/")
+		filePath = filepath.Join(api.ResourcesDir, groupResource.String(), api.ClusterScopedDir, name+".json")
 	}
 
 	itemBytes, err := json.Marshal(item)

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -439,14 +439,14 @@ func TestBackupMethod(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedFiles := sets.NewString(
-		"namespaces/a/configmaps/configMap1.json",
-		"namespaces/b/configmaps/configMap2.json",
-		"namespaces/a/roles.rbac.authorization.k8s.io/role1.json",
+		"resources/configmaps/namespaces/a/configMap1.json",
+		"resources/configmaps/namespaces/b/configMap2.json",
+		"resources/roles.rbac.authorization.k8s.io/namespaces/a/role1.json",
 		// CSRs are not expected because they're unrelated cluster-scoped resources
 	)
 
 	expectedData := map[string]string{
-		"namespaces/a/configmaps/configMap1.json": `
+		"resources/configmaps/namespaces/a/configMap1.json": `
 			{
 				"apiVersion": "v1",
 				"kind": "ConfigMap",
@@ -458,7 +458,7 @@ func TestBackupMethod(t *testing.T) {
 					"a": "b"
 				}
 			}`,
-		"namespaces/b/configmaps/configMap2.json": `
+		"resources/configmaps/namespaces/b/configMap2.json": `
 			{
 				"apiVersion": "v1",
 				"kind": "ConfigMap",
@@ -471,7 +471,7 @@ func TestBackupMethod(t *testing.T) {
 				}
 			}
 		`,
-		"namespaces/a/roles.rbac.authorization.k8s.io/role1.json": `
+		"resources/roles.rbac.authorization.k8s.io/namespaces/a/role1.json": `
 			{
 				"apiVersion": "rbac.authorization.k8s.io/v1beta1",
 				"kind": "Role",
@@ -1114,7 +1114,7 @@ func TestBackupItem(t *testing.T) {
 			namespaceIncludesExcludes: collections.NewIncludesExcludes().Includes("foo"),
 			expectError:               false,
 			expectExcluded:            false,
-			expectedTarHeaderName:     "namespaces/foo/resource.group/bar.json",
+			expectedTarHeaderName:     "resources/resource.group/namespaces/foo/bar.json",
 		},
 		{
 			name: "* namespace include",
@@ -1122,21 +1122,21 @@ func TestBackupItem(t *testing.T) {
 			namespaceIncludesExcludes: collections.NewIncludesExcludes().Includes("*"),
 			expectError:               false,
 			expectExcluded:            false,
-			expectedTarHeaderName:     "namespaces/foo/resource.group/bar.json",
+			expectedTarHeaderName:     "resources/resource.group/namespaces/foo/bar.json",
 		},
 		{
 			name:                  "cluster-scoped",
 			item:                  `{"metadata":{"name":"bar"}}`,
 			expectError:           false,
 			expectExcluded:        false,
-			expectedTarHeaderName: "cluster/resource.group/bar.json",
+			expectedTarHeaderName: "resources/resource.group/cluster/bar.json",
 		},
 		{
 			name:                  "make sure status is deleted",
 			item:                  `{"metadata":{"name":"bar"},"spec":{"color":"green"},"status":{"foo":"bar"}}`,
 			expectError:           false,
 			expectExcluded:        false,
-			expectedTarHeaderName: "cluster/resource.group/bar.json",
+			expectedTarHeaderName: "resources/resource.group/cluster/bar.json",
 		},
 		{
 			name:                "tar header write error",
@@ -1156,7 +1156,7 @@ func TestBackupItem(t *testing.T) {
 			item:                  `{"metadata":{"name":"bar"}}`,
 			expectError:           false,
 			expectExcluded:        false,
-			expectedTarHeaderName: "cluster/resource.group/bar.json",
+			expectedTarHeaderName: "resources/resource.group/cluster/bar.json",
 			customAction:          true,
 			expectedActionID:      "bar",
 		},
@@ -1166,7 +1166,7 @@ func TestBackupItem(t *testing.T) {
 			item:                  `{"metadata":{"namespace": "myns", "name":"bar"}}`,
 			expectError:           false,
 			expectExcluded:        false,
-			expectedTarHeaderName: "namespaces/myns/resource.group/bar.json",
+			expectedTarHeaderName: "resources/resource.group/namespaces/myns/bar.json",
 			customAction:          true,
 			expectedActionID:      "myns/bar",
 		},


### PR DESCRIPTION

    Restructure backups for resource prioritization.
    
    Previously the directory structure separated resources depending on
    whether or not they were cluster or namespace scoped. All cluster
    resources were restored first, then all namespace resources. Priority
    did not apply across both and you could not order any namespace
    resources before any cluster resources.
    
    This restructure sorts first on resource type.
    
    resources/serviceaccounts/namespaces/ns1.json
    resources/nodes/cluster/node1.json
    
    This will break old backups as the format is no longer consistent as
    announced on the Google group.

