### PR TITLE
Fix #137. Remove clock from volume_snapshot_action

### DIFF
--- a/pkg/backup/volume_snapshot_action.go
+++ b/pkg/backup/volume_snapshot_action.go
@@ -22,7 +22,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/clock"
 
 	api "github.com/heptio/ark/pkg/apis/ark/v1"
 	"github.com/heptio/ark/pkg/cloudprovider"
@@ -37,7 +36,6 @@ const zoneLabel = "failure-domain.beta.kubernetes.io/zone"
 // that are backed by compatible cloud volumes.
 type volumeSnapshotAction struct {
 	snapshotService cloudprovider.SnapshotService
-	clock           clock.Clock
 }
 
 func NewVolumeSnapshotAction(snapshotService cloudprovider.SnapshotService) (Action, error) {
@@ -47,7 +45,6 @@ func NewVolumeSnapshotAction(snapshotService cloudprovider.SnapshotService) (Act
 
 	return &volumeSnapshotAction{
 		snapshotService: snapshotService,
-		clock:           clock.RealClock{},
 	}, nil
 }
 

--- a/pkg/backup/volume_snapshot_action_test.go
+++ b/pkg/backup/volume_snapshot_action_test.go
@@ -26,7 +26,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/clock"
 
 	"github.com/heptio/ark/pkg/apis/ark/v1"
 	arktest "github.com/heptio/ark/pkg/util/test"
@@ -190,9 +189,6 @@ func TestVolumeSnapshotAction(t *testing.T) {
 
 			vsa, _ := NewVolumeSnapshotAction(snapshotService)
 			action := vsa.(*volumeSnapshotAction)
-
-			fakeClock := clock.NewFakeClock(time.Now())
-			action.clock = fakeClock
 
 			pv, err := getAsMap(test.pv)
 			if err != nil {


### PR DESCRIPTION
Closed the first PR. This one has one signed commit that removes clock from volume_snapshot_action and volume_snapshot_action_test :)