### PR TITLE
Don't delete 'headless' services

### DIFF
--- a/pkg/restore/restorers/service_restorer.go
+++ b/pkg/restore/restorers/service_restorer.go
@@ -45,7 +45,10 @@ func (sr *serviceRestorer) Prepare(obj runtime.Unstructured, restore *api.Restor
 		return nil, nil, err
 	}
 
-	delete(spec, "clusterIP")
+	// Since clusterIP is an optional key, we can ignore 'not found' errors. Also assuming it was a string already.
+	if val, _ := collections.GetString(spec, "clusterIP"); val != "None" {
+		delete(spec, "clusterIP")
+	}
 
 	ports, err := collections.GetSlice(obj.UnstructuredContent(), "spec.ports")
 	if err != nil {

--- a/pkg/restore/restorers/service_restorer_test.go
+++ b/pkg/restore/restorers/service_restorer_test.go
@@ -43,6 +43,12 @@ func TestServiceRestorerPrepare(t *testing.T) {
 			expectedRes: NewTestUnstructured().WithName("svc-1").WithSpec("foo").WithSpecField("ports", []interface{}{}).Unstructured,
 		},
 		{
+			name:        "headless clusterIP should not be deleted from spec",
+			obj:         NewTestUnstructured().WithName("svc-1").WithSpecField("clusterIP", "None").WithSpecField("ports", []interface{}{}).Unstructured,
+			expectedErr: false,
+			expectedRes: NewTestUnstructured().WithName("svc-1").WithSpecField("clusterIP", "None").WithSpecField("ports", []interface{}{}).Unstructured,
+		},
+		{
 			name: "nodePort (only) should be deleted from all spec.ports",
 			obj: NewTestUnstructured().WithName("svc-1").
 				WithSpecField("ports", []interface{}{


### PR DESCRIPTION
Not currently passing the new unit test, but I believe that's because I've got some sort of type mismatch on the `WithSpecField` arguments, but I'm not 100% sure on that.

I'm fairly confident that the code change fixes the issue, but could use some guidance on what to fix with the test case.

Fixes #168