### PR TITLE
Include git describe info in binary names.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,7 @@ all-tar-bin: $(addprefix tar-bin-, $(CLI_PLATFORMS))
 tar-bin-%:
 	@$(MAKE) ARCH=$* tar-bin
 
+GIT_DESCRIBE = $(shell git describe --tags --always --dirty)
 tar-bin: build
 	mkdir -p _output/release
 
@@ -169,7 +170,7 @@ tar-bin: build
 		tar \
 			-C _output/bin/$(GOOS)/$(GOARCH) \
 			--files-from=- \
-			-zcf _output/release/$(BIN)-$(GOOS)-$(GOARCH).tar.gz
+			-zcf _output/release/$(BIN)-$(GIT_DESCRIBE)-$(GOOS)-$(GOARCH).tar.gz
 
 build-dirs:
 	@mkdir -p _output/bin/$(GOOS)/$(GOARCH)


### PR DESCRIPTION
New format now looks like this:
ark-v0.5.0-44-g72b0bdd-dirty-linux-amd64.tar.gz

Signed-off-by: Andy Goldstein <andy.goldstein@gmail.com>