### PR TITLE
Add more group-resource level logging

### DIFF
--- a/pkg/backup/resource_backupper.go
+++ b/pkg/backup/resource_backupper.go
@@ -123,6 +123,8 @@ func (rb *defaultResourceBackupper) backupResource(
 
 	log := rb.log.WithField("groupResource", grString)
 
+	log.Info("Evaluating resource")
+
 	clusterScoped := !resource.Namespaced
 
 	// If the resource we are backing up is NOT namespaces, and it is cluster-scoped, check to see if
@@ -196,6 +198,7 @@ func (rb *defaultResourceBackupper) backupResource(
 		}
 
 		for _, ns := range namespacesToList {
+			log.WithField("namespace", ns).Info("Getting namespace")
 			unstructured, err := resourceClient.Get(ns, metav1.GetOptions{})
 			if err != nil {
 				errs = append(errs, errors.Wrap(err, "error getting namespace"))
@@ -227,6 +230,7 @@ func (rb *defaultResourceBackupper) backupResource(
 			return err
 		}
 
+		log.WithField("namespace", namespace).Info("Listing items")
 		unstructuredList, err := resourceClient.List(metav1.ListOptions{LabelSelector: rb.labelSelector})
 		if err != nil {
 			return errors.WithStack(err)
@@ -238,6 +242,7 @@ func (rb *defaultResourceBackupper) backupResource(
 			return errors.WithStack(err)
 		}
 
+		log.WithField("namespace", namespace).Infof("Retrieved %d items", len(items))
 		for _, item := range items {
 			unstructured, ok := item.(runtime.Unstructured)
 			if !ok {


### PR DESCRIPTION
This will add new output such as this:

```
time="2017-11-08T17:07:51Z" level=info msg="Evaluating resource" backup=heptio-ark/m5 group=apps/v1 groupResource=replicasets.apps
time="2017-11-08T17:07:51Z" level=info msg="Listing items" backup=heptio-ark/m5 group=apps/v1 groupResource=replicasets.apps namespace=m
time="2017-11-08T17:07:51Z" level=info msg="Retrieved 0 items" backup=heptio-ark/m5 group=apps/v1 groupResource=replicasets.apps namespace=m
```

This should help with diagnosing which groupresources are evaluated and how many items we're trying to process in each.

Signed-off-by: Andy Goldstein <andy.goldstein@gmail.com>