### PR TITLE
Update default TTL to 30 days

### DIFF
--- a/docs/cli-reference/ark_backup_create.md
+++ b/docs/cli-reference/ark_backup_create.md
@@ -26,7 +26,7 @@ ark backup create NAME [flags]
   -l, --selector labelSelector                          only back up resources matching this label selector (default <none>)
       --show-labels                                     show labels in the last column
       --snapshot-volumes optionalBool[=true]            take snapshots of PersistentVolumes as part of the backup
-      --ttl duration                                    how long before the backup can be garbage collected (default 24h0m0s)
+      --ttl duration                                    how long before the backup can be garbage collected (default 720h0m0s)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/ark_create_backup.md
+++ b/docs/cli-reference/ark_create_backup.md
@@ -26,7 +26,7 @@ ark create backup NAME [flags]
   -l, --selector labelSelector                          only back up resources matching this label selector (default <none>)
       --show-labels                                     show labels in the last column
       --snapshot-volumes optionalBool[=true]            take snapshots of PersistentVolumes as part of the backup
-      --ttl duration                                    how long before the backup can be garbage collected (default 24h0m0s)
+      --ttl duration                                    how long before the backup can be garbage collected (default 720h0m0s)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/ark_create_schedule.md
+++ b/docs/cli-reference/ark_create_schedule.md
@@ -27,7 +27,7 @@ ark create schedule NAME [flags]
   -l, --selector labelSelector                          only back up resources matching this label selector (default <none>)
       --show-labels                                     show labels in the last column
       --snapshot-volumes optionalBool[=true]            take snapshots of PersistentVolumes as part of the backup
-      --ttl duration                                    how long before the backup can be garbage collected (default 24h0m0s)
+      --ttl duration                                    how long before the backup can be garbage collected (default 720h0m0s)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/ark_schedule_create.md
+++ b/docs/cli-reference/ark_schedule_create.md
@@ -27,7 +27,7 @@ ark schedule create NAME [flags]
   -l, --selector labelSelector                          only back up resources matching this label selector (default <none>)
       --show-labels                                     show labels in the last column
       --snapshot-volumes optionalBool[=true]            take snapshots of PersistentVolumes as part of the backup
-      --ttl duration                                    how long before the backup can be garbage collected (default 24h0m0s)
+      --ttl duration                                    how long before the backup can be garbage collected (default 720h0m0s)
 ```
 
 ### Options inherited from parent commands

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -37,7 +37,7 @@ Heptio Ark can help you port your resources from one cluster to another, as long
    ```
    ark backup create <BACKUP-NAME>
    ```
-   The default TTL is 24 hours; you can use the `--ttl` flag to change this as necessary.
+   The default TTL is 30 days (720 hours); you can use the `--ttl` flag to change this as necessary.
 
 2. *(Cluster 2)* Make sure that the `persistentVolumeProvider` and `backupStorageProvider` fields in the Ark Config match the ones from *Cluster 1*, so that your new Ark server instance is pointing to the same bucket.
 

--- a/pkg/cmd/cli/backup/create.go
+++ b/pkg/cmd/cli/backup/create.go
@@ -68,7 +68,7 @@ type CreateOptions struct {
 
 func NewCreateOptions() *CreateOptions {
 	return &CreateOptions{
-		TTL:                     24 * time.Hour,
+		TTL:                     30 * 24 * time.Hour,
 		IncludeNamespaces:       flag.NewStringArray("*"),
 		Labels:                  flag.NewMap(),
 		SnapshotVolumes:         flag.NewOptionalBool(nil),


### PR DESCRIPTION
Fixes #195 

Tested against a sample cluster:

```
in /home/nrb/go/src/github.com/heptio/ark (git) extend-ttl U
% _output/bin/linux/amd64/ark backup create nginx-app -l namespace=nginx-app
Backup "nginx-app" created successfully.

x1c in /home/nrb/go/src/github.com/heptio/ark (git) extend-ttl U
% _output/bin/linux/amd64/ark backup create nginx-app

x1c in /home/nrb/go/src/github.com/heptio/ark (git) extend-ttl U
% _output/bin/linux/amd64/ark backup get nginx-app
NAME        STATUS    CREATED                         EXPIRES   SELECTOR
nginx-app   New       2017-11-14 16:45:53 -0500 EST   29d       namespace=nginx-app

in /home/nrb/go/src/github.com/heptio/ark (git) extend-ttl U
% _output/bin/linux/amd64/ark backup get nginx-app -o yaml
apiVersion: ark.heptio.com/v1
kind: Backup
metadata:
  creationTimestamp: 2017-11-14T21:45:53Z
  name: nginx-app
  namespace: heptio-ark
  resourceVersion: "18028"
  selfLink: /apis/ark.heptio.com/v1/namespaces/heptio-ark/backups/nginx-app
  uid: 2ffc39af-c985-11e7-a734-02062c38ba36
spec:
  excludedNamespaces: null
  excludedResources: null
  hooks:
    resources: null
  includeClusterResources: null
  includedNamespaces:
  - '*'
  includedResources: null
  labelSelector:
    matchLabels:
      namespace: nginx-app
  snapshotVolumes: null
  ttl: 720h0m0s
status:
  expiration: null
  phase: ""
  validationErrors: null
  version: 0
  volumeBackups: null
```