### PR TITLE
Fix log location hook prefix stripping

### DIFF
--- a/pkg/util/logging/log_location_hook.go
+++ b/pkg/util/logging/log_location_hook.go
@@ -28,7 +28,7 @@ const (
 	logSourceField          = "logSource"
 	logSourceSetMarkerField = "@logSourceSetBy"
 	logrusPackage           = "github.com/sirupsen/logrus"
-	arkPackage              = "github.com/heptio/ark"
+	arkPackage              = "github.com/heptio/ark/"
 	arkPackageLen           = len(arkPackage)
 )
 
@@ -90,11 +90,7 @@ func (h *LogLocationHook) Fire(entry *logrus.Entry) error {
 		// we're in Ark server and not logging something that has the marker
 		// set (which would indicate the log statement is coming from a plugin).
 		if h.loggerName != "" || getLogSourceSetMarker(entry) == "" {
-			file := frame.File
-			if index := strings.Index(file, arkPackage); index != -1 {
-				// strip off .../github.com/heptio/ark/ so we just have pkg/...
-				file = frame.File[index+arkPackageLen+1:]
-			}
+			file := removeArkPackagePrefix(frame.File)
 
 			entry.Data[logSourceField] = fmt.Sprintf("%s:%d", file, frame.Line)
 		}
@@ -122,4 +118,13 @@ func getLogSourceSetMarker(entry *logrus.Entry) string {
 	}
 
 	return fmt.Sprintf("%s", nameVal)
+}
+
+func removeArkPackagePrefix(file string) string {
+	if index := strings.Index(file, arkPackage); index != -1 {
+		// strip off .../github.com/heptio/ark/ so we just have pkg/...
+		return file[index+arkPackageLen:]
+	}
+
+	return file
 }

--- a/pkg/util/logging/log_location_hook_test.go
+++ b/pkg/util/logging/log_location_hook_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2017 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveArkPackagePrefix(t *testing.T) {
+	assert.Equal(t, "pkg/foo.go", removeArkPackagePrefix("github.com/heptio/ark/pkg/foo.go"))
+	assert.Equal(t, "github.com/heptio/ark-plugin-example/foo.go", removeArkPackagePrefix("github.com/heptio/ark-plugin-example/foo.go"))
+}


### PR DESCRIPTION
The log location hook was matching github.com/heptio/ark and stripping
off that + 1 more char. This meant that
github.com/heptio/ark-plugin-example/foo.go was being listed as
plugin-example/foo.go instead of
github.com/heptio/ark-plugin-example/foo.go.

Signed-off-by: Andy Goldstein <andy.goldstein@gmail.com>