### PR TITLE
Bug fixes: obj/block store plugin logging and remapped namespaces issue

### DIFF
--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -341,6 +341,12 @@ func (ctx *context) restoreFromDir(dir string) (api.RestoreResult, api.RestoreRe
 	existingNamespaces := sets.NewString()
 
 	for _, resource := range ctx.prioritizedResources {
+		// we don't want to explicitly restore namespace API objs because we'll handle
+		// them as a special case prior to restoring anything into them
+		if resource.Group == "" && resource.Resource == "namespaces" {
+			continue
+		}
+
 		rscDir := resourceDirsMap[resource.String()]
 		if rscDir == nil {
 			continue


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

-Each plugin needs its own logrusAdapter so that when item actions are redirected to log in the backup/restore logs, the obj/block store plugins continue logging to the server log.
-When restoring, don't restore Namespace API objects independently. They'll be restored when objects get restored into them. The bug seen was that when remapping namespaces, an empty namespace with the old name got created (the objects were correctly restored into the renamed NS).