### PR TITLE
[WIP] bug fixes

### DIFF
--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -93,6 +93,12 @@ func prioritizeResources(helper discovery.Helper, priorities []string, includedR
 			logger.WithField("groupResource", gr).Info("Not including resource")
 			continue
 		}
+		// we don't want to explicitly restore namespace API objs because we'll handle
+		// them as a special case prior to restoring anything into them
+		if gr.Group == "" && gr.Resource == "namespaces" {
+			continue
+		}
+
 		ret = append(ret, gr)
 		set.Insert(gr.String())
 	}
@@ -111,6 +117,11 @@ func prioritizeResources(helper discovery.Helper, priorities []string, includedR
 
 			if !includedResources.ShouldInclude(gr.String()) {
 				logger.WithField("groupResource", gr.String()).Info("Not including resource")
+				continue
+			}
+			// we don't want to explicitly restore namespace API objs because we'll handle
+			// them as a special case prior to restoring anything into them
+			if gr.Group == "" && gr.Resource == "namespaces" {
 				continue
 			}
 


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

-don't restore namespace API objects as a normal resource. They get created prior to any objects being restored into them. The observed bug was that when restoring a namespace and remapping it to a new name, everything is correctly restored into the new NS, but an empty NS with the old name is also created.