### PR TITLE
Add pprof support to ark server

### DIFF
--- a/changelogs/unreleased/234-ncdc
+++ b/changelogs/unreleased/234-ncdc
@@ -1,0 +1,1 @@
+Add pprof support to the Ark server


### PR DESCRIPTION
Fixes #85 

There is a new `ark server` flag: `--profiler-address`. It defaults to `localhost:6060`. This means by default it's only accessible if you use `kubectl port-forward`, but you can change it to something like `:6060` and put a service + ingress in front if you want to make it publicly accessible. There is no authentication for it at this time.

This does not add pprof support for plugin processes. Those tend to be relatively short-lived. If needed, in the future we could add some sort of debugging flag that would capture various pprof data from plugin processes and store it in files local to the ark server pod, and they could be retrieved after the fact by hand using `kubectl cp` or some other mechanism.