### PR TITLE
Pass VERSION all the way down during 'make release'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ build: _output/bin/$(GOOS)/$(GOARCH)/$(BIN)
 
 _output/bin/$(GOOS)/$(GOARCH)/$(BIN): build-dirs
 	@echo "building: $@"
-	@$(MAKE) shell CMD="-c '\
+	$(MAKE) shell CMD="-c '\
 		GOOS=$(GOOS) \
 		GOARCH=$(GOARCH) \
 		VERSION=$(VERSION) \
@@ -156,7 +156,7 @@ checksum:
 all-tar-bin: $(addprefix tar-bin-, $(CLI_PLATFORMS))
 
 tar-bin-%:
-	@$(MAKE) ARCH=$* tar-bin
+	$(MAKE) ARCH=$* VERSION=$(VERSION) tar-bin
 
 GIT_DESCRIBE = $(shell git describe --tags --always --dirty)
 tar-bin: build


### PR DESCRIPTION
Will cherry-pick up to master.

Sample output:

```
$ vagrant@f26:~/go/src/github.com/heptio/ark (makefile-pass-version-through) VERSION=testing123 make release                                                                                                                                                                                                                     [24/24]
make ARCH=linux-amd64 VERSION=testing123 tar-bin
make[1]: Entering directory '/home/vagrant/go/src/github.com/heptio/ark'
building: _output/bin/linux/amd64/ark
make shell CMD="-c '\
        GOOS=linux \
        GOARCH=amd64 \
        VERSION=testing123 \
        PKG=github.com/heptio/ark \
        BIN=ark \
        OUTPUT_DIR=/output/linux/amd64 \
        ./hack/build.sh'"
make[2]: Entering directory '/home/vagrant/go/src/github.com/heptio/ark'
make[2]: Leaving directory '/home/vagrant/go/src/github.com/heptio/ark'
mkdir -p _output/release
(cd _output/bin/linux/amd64 && ls ark*) | \
        tar \
                -C _output/bin/linux/amd64 \
                --files-from=- \
                -zcf _output/release/ark-v0.6.0-1-gd053dc2-linux-amd64.tar.gz
make[1]: Leaving directory '/home/vagrant/go/src/github.com/heptio/ark'
make ARCH=linux-arm VERSION=testing123 tar-bin
make[1]: Entering directory '/home/vagrant/go/src/github.com/heptio/ark'
building: _output/bin/linux/arm/ark
make shell CMD="-c '\
        GOOS=linux \
        GOARCH=arm \
        VERSION=testing123 \
        PKG=github.com/heptio/ark \
        BIN=ark \
        OUTPUT_DIR=/output/linux/arm \
        ./hack/build.sh'"
make[2]: Entering directory '/home/vagrant/go/src/github.com/heptio/ark'
make[2]: Leaving directory '/home/vagrant/go/src/github.com/heptio/ark'
mkdir -p _output/release
(cd _output/bin/linux/arm && ls ark*) | \
        tar \
                -C _output/bin/linux/arm \
                --files-from=- \
                -zcf _output/release/ark-v0.6.0-1-gd053dc2-linux-arm.tar.gz
make[1]: Leaving directory '/home/vagrant/go/src/github.com/heptio/ark'
make ARCH=linux-arm64 VERSION=testing123 tar-bin
make[1]: Entering directory '/home/vagrant/go/src/github.com/heptio/ark'
building: _output/bin/linux/arm64/ark
make shell CMD="-c '\
        GOOS=linux \
        GOARCH=arm64 \
        VERSION=testing123 \
        PKG=github.com/heptio/ark \
        BIN=ark \
        OUTPUT_DIR=/output/linux/arm64 \
        ./hack/build.sh'"
make[2]: Entering directory '/home/vagrant/go/src/github.com/heptio/ark'
make[2]: Leaving directory '/home/vagrant/go/src/github.com/heptio/ark'
mkdir -p _output/release
(cd _output/bin/linux/arm64 && ls ark*) | \
        tar \
                -C _output/bin/linux/arm64 \
                --files-from=- \
                -zcf _output/release/ark-v0.6.0-1-gd053dc2-linux-arm64.tar.gz
make[1]: Leaving directory '/home/vagrant/go/src/github.com/heptio/ark'
make ARCH=darwin-amd64 VERSION=testing123 tar-bin
make[1]: Entering directory '/home/vagrant/go/src/github.com/heptio/ark'
building: _output/bin/darwin/amd64/ark
make shell CMD="-c '\
        GOOS=darwin \
        GOARCH=amd64 \
        VERSION=testing123 \
        PKG=github.com/heptio/ark \
        BIN=ark \
        OUTPUT_DIR=/output/darwin/amd64 \
        ./hack/build.sh'"
make[2]: Entering directory '/home/vagrant/go/src/github.com/heptio/ark'
make[2]: Leaving directory '/home/vagrant/go/src/github.com/heptio/ark'
mkdir -p _output/release
(cd _output/bin/darwin/amd64 && ls ark*) | \
        tar \
                -C _output/bin/darwin/amd64 \
                --files-from=- \
                -zcf _output/release/ark-v0.6.0-1-gd053dc2-darwin-amd64.tar.gz
make[1]: Leaving directory '/home/vagrant/go/src/github.com/heptio/ark'
make ARCH=windows-amd64 VERSION=testing123 tar-bin
make[1]: Entering directory '/home/vagrant/go/src/github.com/heptio/ark'
building: _output/bin/windows/amd64/ark
make shell CMD="-c '\
        GOOS=windows \
        GOARCH=amd64 \
        VERSION=testing123 \
        PKG=github.com/heptio/ark \
        BIN=ark \
        OUTPUT_DIR=/output/windows/amd64 \
        ./hack/build.sh'"
make[2]: Entering directory '/home/vagrant/go/src/github.com/heptio/ark'
make[2]: Leaving directory '/home/vagrant/go/src/github.com/heptio/ark'
mkdir -p _output/release
(cd _output/bin/windows/amd64 && ls ark*) | \
        tar \
                -C _output/bin/windows/amd64 \
                --files-from=- \
                -zcf _output/release/ark-v0.6.0-1-gd053dc2-windows-amd64.tar.gz
make[1]: Leaving directory '/home/vagrant/go/src/github.com/heptio/ark'
f362d0632917dbb94ea0251550896a19e4224d840b1c6bb38e73c4cf4d25ee6d  ark-v0.6.0-1-gd053dc2-darwin-amd64.tar.gz
a100ed032dff8f2f12e01a2731e2a67c158de2179d3fad3dfde4c175cb3947f6  ark-v0.6.0-1-gd053dc2-linux-amd64.tar.gz
9503c5b6c77e3bcd005e21d818452c306fd48128aa9f2d96dfbf447d04296dea  ark-v0.6.0-1-gd053dc2-linux-arm64.tar.gz
f19e884e647131c685cd3c364ba48492ea2efd5b8ed6833e002c0753d7eb1f46  ark-v0.6.0-1-gd053dc2-linux-arm.tar.gz
f56e0cd796c05549ed5724923885aa483356b08da802ed147afb5110e48f0103  ark-v0.6.0-1-gd053dc2-windows-amd64.tar.gz
db632d0df7236d4a5af89db91e9f10623301314ffeecd68f6c9cc31e7c8b55ff  CHECKSUM

vagrant@f26:~/go/src/github.com/heptio/ark (makefile-pass-version-through) tar xf _output/release/ark-v0.6.0-1-gd053dc2-linux-amd64.tar.gz
vagrant@f26:~/go/src/github.com/heptio/ark (makefile-pass-version-through) ./ark version
Version: testing123
Git commit: v0.6.0-1-gd053dc2
Git tree state: dirty

# on Mac
$ ./ark version
Version: testing123
Git commit: v0.6.0-1-gd053dc2
Git tree state: dirty
```

Signed-off-by: Andy Goldstein <andy.goldstein@gmail.com>