### PR TITLE
Add serviceaccounts to prioritized resources

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -270,6 +270,7 @@ var defaultResourcePriorities = []string{
 	"persistentvolumeclaims",
 	"secrets",
 	"configmaps",
+	"serviceaccounts",
 }
 
 func applyConfigDefaults(c *api.Config, logger logrus.FieldLogger) {


### PR DESCRIPTION
Add serviceaccounts to the default list of prioritized resources used
when restoring.

Signed-off-by: Andy Goldstein <andy.goldstein@gmail.com>

Fixes #239