### PR TITLE
Clarify backup and restore creation messages

### DIFF
--- a/pkg/cmd/cli/backup/create.go
+++ b/pkg/cmd/cli/backup/create.go
@@ -143,6 +143,7 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 		return err
 	}
 
-	fmt.Printf("Backup %q created successfully.\n", backup.Name)
+	fmt.Printf("Backup request %q submitted successfully.\n", backup.Name)
+	fmt.Printf("Run `ark backup describe %s` for more details.\n", backup.Name)
 	return nil
 }

--- a/pkg/cmd/cli/restore/create.go
+++ b/pkg/cmd/cli/restore/create.go
@@ -144,6 +144,7 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 		return err
 	}
 
-	fmt.Printf("Restore %q created successfully.\n", restore.Name)
+	fmt.Printf("Restore request %q submitted successfully.\n", restore.Name)
+	fmt.Printf("Run `ark restore describe %s` for more details.\n", restore.Name)
 	return nil
 }


### PR DESCRIPTION
When running `ark <resource> create`, a request is sent to the server,
but the status is not immediately known. Inform the user that a request
was sent and provide a way to get more information on it.

I'm open to changing the message text if others think of something better.

Fixes #232 