### PR TITLE
document ability to change namespace

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+remote_theme: tomjoht/documentation-theme-jekyll

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,2 @@
-remote_theme: tomjoht/documentation-theme-jekyll
+theme: jekyll-theme-minimal
+

--- a/docs/config-definition.md
+++ b/docs/config-definition.md
@@ -12,7 +12,9 @@
 
 Heptio Ark defines its own Config object (a custom resource) for specifying Ark backup and cloud provider settings. When the Ark server is first deployed, it waits until you create a Config--specifically one named `default`--in the `heptio-ark` namespace.
 
-> *NOTE*: There is an underlying assumption that you're running the Ark server as a Kubernetes deployment. If the `default` Config is modified, the server shuts down gracefully. Once the kubelet restarts the Ark server pod, the server then uses the updated Config values.
+In version 0.7.0 and later, you can run Ark in any namespace. In earlier versions, the `heptio-ark` namespace was required.
+
+> **NOTE**: This example assumes that the Ark server is running as a Kubernetes deployment. If you modify the `default` Config, the server shuts down gracefully. The kubelet then restarts the Ark server pod with the updated Config values.
 
 ## Example
 


### PR DESCRIPTION
Fixes issue #290 
with apologies for messy commit history, but my local log isn't giving me enough info to squash or remove commits with confidence. Can clean up before merge with some coaching. Figure it's better to get review going first.
Do we want to provide this information elsewhere in the docs? It'll go in the release notes (CHANGELOG.md), but if y'all have suggestions for other locations I'm open to considering them. I pondered the README, but there's currently no obvious place for it there.