### PR TITLE
adds helm chart to ark

### DIFF
--- a/contribution/ark-server/.helmignore
+++ b/contribution/ark-server/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/contribution/ark-server/Chart.yaml
+++ b/contribution/ark-server/Chart.yaml
@@ -4,5 +4,5 @@ description: A Helm chart for ark-server
 name: ark-server
 version: 0.6.0
 maintainers:
-- name: Domenico Caruso
+- name: domcar
   email: domenico.caruso@de.clara.net

--- a/contribution/ark-server/Chart.yaml
+++ b/contribution/ark-server/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for ark-server
+name: ark-server
+version: 0.6.0
+maintainers:
+- name: Domenico Caruso
+  email: domenico.caruso@de.clara.net

--- a/contribution/ark-server/README.md
+++ b/contribution/ark-server/README.md
@@ -1,0 +1,39 @@
+# Ark-server
+
+This helm chart install ark-server version v0.6.0
+
+## Premise
+Helm cannot handle properly CRD becauses it has a validation mechanism that checks the installation before the CRD are actually created,
+hence each resource that uses a CRD cannot be validated because the CRD doesn't exist yet!
+
+The trick here is to create CRD via helm chart, and only after (using a `post-install`) to install the resources with a container.
+The container has the only job to execute a `kubectl create -f filename` and create the resources.
+
+At the same time the resources created with the hook are completely transparent to Helm, that is, when you delete the
+chart those resources remain there. Hence we need a sencond hook for deleting them (see delete.yaml)
+
+## Content
+- `templates/00-prereqs.yaml` this file contains the CRD needed by ARK
+- `install.yaml` This is the container that will deploy ark-server and its configuration
+- `configmap.yaml` Configmap will be mounted to the container as a file and subsequently used as k8s manifest for deploy
+- `delete.yaml` Deletes the resources created by `install.yaml`
+
+## ConfigMap customization
+Since we want to have a customizable chart it's important that the configmap is a template and not a static file.
+To do this we add the keyword `tpl` when reading the file
+- {{ (tpl (.Files.Glob "static/*").AsConfig .) | indent 2 }}
+
+## Heptio Secret
+Ark server needs a IAM service accoutn in order to run, if you don't have it you must create it: 
+https://github.com/heptio/ark/blob/v0.6.0/docs/cloud-provider-specifics.md#gcp
+
+
+And then
+```
+kubectl create secret generic cloud-credentials --namespace heptio-ark --from-file cloud=credentials-ark
+```
+
+## How to
+```
+helm install --name ark-server --namespace heptio-ark ./ark-server
+```

--- a/contribution/ark-server/static/01-config-deploy.yaml
+++ b/contribution/ark-server/static/01-config-deploy.yaml
@@ -5,12 +5,12 @@ metadata:
   namespace: heptio-ark
   name: default
 persistentVolumeProvider:
-  name: {{ .Values.configuration.cloudprovider  }}
+  name: {{ required "PLEASE CHANGE VALUE" .Values.configuration.cloudprovider  }}
   config:
-    project: {{ .Values.configuration.project  }}
+    project: {{ required "PLEASE CHANGE VALUE" .Values.configuration.project  }}
 backupStorageProvider:
-  name: {{ .Values.configuration.cloudprovider  }}
-  bucket: {{ .Values.configuration.bucket  }}
+  name: {{ required "PLEASE CHANGE VALUE" .Values.configuration.cloudprovider  }}
+  bucket: {{ required "PLEASE CHANGE VALUE" .Values.configuration.bucket  }}
 backupSyncPeriod: 30m
 gcSyncPeriod: 30m
 scheduleSyncPeriod: 1m
@@ -44,7 +44,7 @@ spec:
             - name: plugins
               mountPath: /plugins
           env:
-            - name: {{ .Values.configuration.credentials }}
+            - name: {{ required "PLEASE CHANGE VALUE" .Values.configuration.credentials }}
               value: /credentials/cloud
       volumes:
         - name: cloud-credentials

--- a/contribution/ark-server/static/01-config-deploy.yaml
+++ b/contribution/ark-server/static/01-config-deploy.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: ark.heptio.com/v1
+kind: Config
+metadata:
+  namespace: heptio-ark
+  name: default
+persistentVolumeProvider:
+  name: {{ .Values.configuration.cloudprovider  }}
+  config:
+    project: {{ .Values.configuration.project  }}
+backupStorageProvider:
+  name: {{ .Values.configuration.cloudprovider  }}
+  bucket: {{ .Values.configuration.bucket  }}
+backupSyncPeriod: 30m
+gcSyncPeriod: 30m
+scheduleSyncPeriod: 1m
+restoreOnlyMode: false
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  namespace: heptio-ark
+  name: ark
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: ark
+    spec:
+      restartPolicy: Always
+      serviceAccountName: ark
+      containers:
+        - name: ark
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          command:
+            - /ark
+          args:
+            - server
+          volumeMounts:
+            - name: cloud-credentials
+              mountPath: /credentials
+            - name: plugins
+              mountPath: /plugins
+          env:
+            - name: {{ .Values.configuration.credentials }}
+              value: /credentials/cloud
+      volumes:
+        - name: cloud-credentials
+          secret:
+            secretName: {{ .Values.secret.name }}
+        - name: plugins
+          emptyDir: {}

--- a/contribution/ark-server/templates/00-prereqs.yaml
+++ b/contribution/ark-server/templates/00-prereqs.yaml
@@ -97,7 +97,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ark
-  namespace: heptio-ark
+  namespace: {{ .Values.configuration.namespace }}
   labels:
     component: ark
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -118,7 +118,7 @@ metadata:
     app: {{ template "ark-server.name" . }}
 subjects:
   - kind: ServiceAccount
-    namespace: heptio-ark
+    namespace: {{ .Values.configuration.namespace }}
     name: ark
 roleRef:
   kind: ClusterRole
@@ -129,7 +129,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
-  namespace: heptio-ark
+  namespace: {{ .Values.configuration.namespace }}
   name: ark
   labels:
     component: ark
@@ -149,7 +149,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  namespace: heptio-ark
+  namespace: {{ .Values.configuration.namespace }}
   name: ark
   labels:
     component: ark
@@ -159,7 +159,7 @@ metadata:
     app: {{ template "ark-server.name" . }}
 subjects:
   - kind: ServiceAccount
-    namespace: heptio-ark
+    namespace: {{ .Values.configuration.namespace }}
     name: ark
 roleRef:
   kind: Role
@@ -171,7 +171,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "ark-server.deploySA" . }}
-  namespace: heptio-ark
+  namespace: {{ .Values.configuration.namespace }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
@@ -201,7 +201,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: deploy-ark
-  namespace: heptio-ark
+  namespace: {{ .Values.configuration.namespace }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
@@ -214,5 +214,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "ark-server.deploySA" . }}
-  namespace: heptio-ark
+  namespace: {{ .Values.configuration.namespace }}
 {{- end }}

--- a/contribution/ark-server/templates/00-prereqs.yaml
+++ b/contribution/ark-server/templates/00-prereqs.yaml
@@ -1,0 +1,166 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: backups.ark.heptio.com
+  labels:
+    component: ark
+spec:
+  group: ark.heptio.com
+  version: v1
+  scope: Namespaced
+  names:
+    plural: backups
+    kind: Backup
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: schedules.ark.heptio.com
+  labels:
+    component: ark
+spec:
+  group: ark.heptio.com
+  version: v1
+  scope: Namespaced
+  names:
+    plural: schedules
+    kind: Schedule
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: restores.ark.heptio.com
+  labels:
+    component: ark
+spec:
+  group: ark.heptio.com
+  version: v1
+  scope: Namespaced
+  names:
+    plural: restores
+    kind: Restore
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: configs.ark.heptio.com
+  labels:
+    component: ark
+spec:
+  group: ark.heptio.com
+  version: v1
+  scope: Namespaced
+  names:
+    plural: configs
+    kind: Config
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: downloadrequests.ark.heptio.com
+  labels:
+    component: ark
+spec:
+  group: ark.heptio.com
+  version: v1
+  scope: Namespaced
+  names:
+    plural: downloadrequests
+    kind: DownloadRequest
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ark
+  namespace: heptio-ark
+  labels:
+    component: ark
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: ark
+  labels:
+    component: ark
+subjects:
+  - kind: ServiceAccount
+    namespace: heptio-ark
+    name: ark
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  namespace: heptio-ark
+  name: ark
+  labels:
+    component: ark
+rules:
+  - apiGroups:
+      - ark.heptio.com
+    verbs:
+      - "*"
+    resources:
+      - "*"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  namespace: heptio-ark
+  name: ark
+  labels:
+    component: ark
+subjects:
+  - kind: ServiceAccount
+    namespace: heptio-ark
+    name: ark
+roleRef:
+  kind: Role
+  name: ark
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deploy-ark
+  namespace: heptio-ark
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: deploy-ark
+rules:
+- apiGroups: ['*']
+  resources: ['*']
+  verbs: ['*']
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: deploy-ark
+  namespace: heptio-ark
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: deploy-ark
+subjects:
+- kind: ServiceAccount
+  name: deploy-ark
+  namespace: heptio-ark

--- a/contribution/ark-server/templates/00-prereqs.yaml
+++ b/contribution/ark-server/templates/00-prereqs.yaml
@@ -4,6 +4,10 @@ metadata:
   name: backups.ark.heptio.com
   labels:
     component: ark
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app: {{ template "ark-server.name" . }}
 spec:
   group: ark.heptio.com
   version: v1
@@ -19,6 +23,10 @@ metadata:
   name: schedules.ark.heptio.com
   labels:
     component: ark
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app: {{ template "ark-server.name" . }}
 spec:
   group: ark.heptio.com
   version: v1
@@ -34,6 +42,10 @@ metadata:
   name: restores.ark.heptio.com
   labels:
     component: ark
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app: {{ template "ark-server.name" . }}
 spec:
   group: ark.heptio.com
   version: v1
@@ -49,6 +61,10 @@ metadata:
   name: configs.ark.heptio.com
   labels:
     component: ark
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app: {{ template "ark-server.name" . }}
 spec:
   group: ark.heptio.com
   version: v1
@@ -64,6 +80,10 @@ metadata:
   name: downloadrequests.ark.heptio.com
   labels:
     component: ark
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app: {{ template "ark-server.name" . }}
 spec:
   group: ark.heptio.com
   version: v1
@@ -80,6 +100,10 @@ metadata:
   namespace: heptio-ark
   labels:
     component: ark
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app: {{ template "ark-server.name" . }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -88,6 +112,10 @@ metadata:
   name: ark
   labels:
     component: ark
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app: {{ template "ark-server.name" . }}
 subjects:
   - kind: ServiceAccount
     namespace: heptio-ark
@@ -105,6 +133,10 @@ metadata:
   name: ark
   labels:
     component: ark
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app: {{ template "ark-server.name" . }}
 rules:
   - apiGroups:
       - ark.heptio.com
@@ -121,6 +153,10 @@ metadata:
   name: ark
   labels:
     component: ark
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app: {{ template "ark-server.name" . }}
 subjects:
   - kind: ServiceAccount
     namespace: heptio-ark
@@ -134,9 +170,15 @@ roleRef:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: deploy-ark
+  name: {{ template "ark-server.deploySA" . }}
   namespace: heptio-ark
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app: {{ template "ark-server.name" . }}
 
+{{- if .Values.rbac.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -145,6 +187,10 @@ metadata:
     rbac.authorization.kubernetes.io/autoupdate: "true"
   labels:
     kubernetes.io/bootstrapping: rbac-defaults
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app: {{ template "ark-server.name" . }}
   name: deploy-ark
 rules:
 - apiGroups: ['*']
@@ -156,11 +202,17 @@ kind: ClusterRoleBinding
 metadata:
   name: deploy-ark
   namespace: heptio-ark
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app: {{ template "ark-server.name" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: deploy-ark
 subjects:
 - kind: ServiceAccount
-  name: deploy-ark
+  name: {{ template "ark-server.deploySA" . }}
   namespace: heptio-ark
+{{- end }}

--- a/contribution/ark-server/templates/00-prereqs.yaml
+++ b/contribution/ark-server/templates/00-prereqs.yaml
@@ -1,3 +1,11 @@
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace.name }}
+{{- end }}
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -97,7 +105,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ark
-  namespace: {{ .Values.configuration.namespace }}
+  namespace: {{ .Values.namespace.name }}
   labels:
     component: ark
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -118,7 +126,7 @@ metadata:
     app: {{ template "ark-server.name" . }}
 subjects:
   - kind: ServiceAccount
-    namespace: {{ .Values.configuration.namespace }}
+    namespace: {{ .Values.namespace.name }}
     name: ark
 roleRef:
   kind: ClusterRole
@@ -129,7 +137,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
-  namespace: {{ .Values.configuration.namespace }}
+  namespace: {{ .Values.namespace.name }}
   name: ark
   labels:
     component: ark
@@ -149,7 +157,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  namespace: {{ .Values.configuration.namespace }}
+  namespace: {{ .Values.namespace.name }}
   name: ark
   labels:
     component: ark
@@ -159,7 +167,7 @@ metadata:
     app: {{ template "ark-server.name" . }}
 subjects:
   - kind: ServiceAccount
-    namespace: {{ .Values.configuration.namespace }}
+    namespace: {{ .Values.namespace.name }}
     name: ark
 roleRef:
   kind: Role
@@ -171,7 +179,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "ark-server.deploySA" . }}
-  namespace: {{ .Values.configuration.namespace }}
+  namespace: {{ .Values.namespace.name }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
@@ -201,7 +209,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: deploy-ark
-  namespace: {{ .Values.configuration.namespace }}
+  namespace: {{ .Values.namespace.name }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
@@ -214,5 +222,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "ark-server.deploySA" . }}
-  namespace: {{ .Values.configuration.namespace }}
+  namespace: {{ .Values.namespace.name }}
 {{- end }}

--- a/contribution/ark-server/templates/NOTES.txt
+++ b/contribution/ark-server/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "ark-server.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "ark-server.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "ark-server.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "ark-server.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/contribution/ark-server/templates/_helpers.tpl
+++ b/contribution/ark-server/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ark-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ark-server.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ark-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/contribution/ark-server/templates/_helpers.tpl
+++ b/contribution/ark-server/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "ark-server.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use for deploying
+*/}}
+{{- define "ark-server.deploySA" -}}
+{{- if .Values.serviceAccount.deploy.create -}}
+    {{ default (include "ark-server.fullname" .) .Values.serviceAccount.deploy.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.deploy.name }}
+{{- end -}}
+{{- end -}}

--- a/contribution/ark-server/templates/configmap.yaml
+++ b/contribution/ark-server/templates/configmap.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ark-server-config
+  namespace: heptio-ark
 data:
 {{ (tpl (.Files.Glob "static/*").AsConfig .) | indent 2 }}

--- a/contribution/ark-server/templates/configmap.yaml
+++ b/contribution/ark-server/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ark-server-config
+data:
+{{ (tpl (.Files.Glob "static/*").AsConfig .) | indent 2 }}

--- a/contribution/ark-server/templates/configmap.yaml
+++ b/contribution/ark-server/templates/configmap.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ark-server-config
-  namespace: heptio-ark
+  namespace: {{ .Values.namespace.name }}
 data:
 {{ (tpl (.Files.Glob "static/*").AsConfig .) | indent 2 }}

--- a/contribution/ark-server/templates/delete.yaml
+++ b/contribution/ark-server/templates/delete.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: delete-ark
+  namespace: heptio-ark
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -9,6 +10,7 @@ spec:
   template:
     metadata:
       name: delete-ark
+      namespace: heptio-ark
     spec:
       restartPolicy: Never
       containers:

--- a/contribution/ark-server/templates/delete.yaml
+++ b/contribution/ark-server/templates/delete.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-ark
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: delete-ark
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: delete-ark
+        image: claranet/gcloud-kubectl-docker
+        imagePullPolicy: Always
+        command: ["kubectl","delete","-f","/tmp/"]
+        volumeMounts:
+          - name: ark-server-config
+            mountPath: /tmp
+      volumes:
+        - name: ark-server-config
+          configMap:
+            name: ark-server-config
+      serviceAccountName: deploy-ark

--- a/contribution/ark-server/templates/delete.yaml
+++ b/contribution/ark-server/templates/delete.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: delete-ark
-  namespace: heptio-ark
+  namespace: {{ .Values.namespace.name }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       name: delete-ark
-      namespace: heptio-ark
+      namespace: {{ .Values.namespace.name }}
     spec:
       restartPolicy: Never
       containers:

--- a/contribution/ark-server/templates/install.yaml
+++ b/contribution/ark-server/templates/install.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: deploy-ark
+  namespace: heptio-ark
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -9,6 +10,7 @@ spec:
   template:
     metadata:
       name: deploy-ark
+      namespace: heptio-ark
     spec:
       restartPolicy: Never
       containers:

--- a/contribution/ark-server/templates/install.yaml
+++ b/contribution/ark-server/templates/install.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: deploy-ark
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: deploy-ark
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: deploy-ark
+        image: claranet/gcloud-kubectl-docker
+        imagePullPolicy: Always
+        command: ["kubectl","create","-f","/tmp/"]
+        volumeMounts:
+          - name: ark-server-config
+            mountPath: /tmp
+      volumes:
+        - name: ark-server-config
+          configMap:
+            name: ark-server-config
+      serviceAccountName: deploy-ark

--- a/contribution/ark-server/templates/install.yaml
+++ b/contribution/ark-server/templates/install.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: deploy-ark
-  namespace: heptio-ark
+  namespace: {{ .Values.namespace.name }}
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       name: deploy-ark
-      namespace: heptio-ark
+      namespace: {{ .Values.namespace.name }}
     spec:
       restartPolicy: Never
       containers:

--- a/contribution/ark-server/values.yaml
+++ b/contribution/ark-server/values.yaml
@@ -5,10 +5,10 @@
 replicaCount: 1
 
 configuration:
-  cloudprovider: changeme
-  project: changeme
-  bucket: changeme
-  credentials: changeme
+  cloudprovider:
+  project:
+  bucket:
+  credentials:
 
 image:
   repository: gcr.io/heptio-images/ark
@@ -21,8 +21,6 @@ secret:
 service:
   type: ClusterIP
   port: 80
-
-
 
 rbac:
   create: true

--- a/contribution/ark-server/values.yaml
+++ b/contribution/ark-server/values.yaml
@@ -9,6 +9,7 @@ configuration:
   project:
   bucket:
   credentials:
+  namespace: heptio-ark
 
 image:
   repository: gcr.io/heptio-images/ark

--- a/contribution/ark-server/values.yaml
+++ b/contribution/ark-server/values.yaml
@@ -6,10 +6,13 @@ replicaCount: 1
 
 configuration:
   cloudprovider:
-  project:
-  bucket:
+  project: 
+  bucket: 
   credentials:
-  namespace: heptio-ark
+
+namespace:
+  create: true
+  name: heptio-ark
 
 image:
   repository: gcr.io/heptio-images/ark

--- a/contribution/ark-server/values.yaml
+++ b/contribution/ark-server/values.yaml
@@ -1,0 +1,54 @@
+# Default values for ark-server.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+configuration:
+  cloudprovider: changeme
+  project: changeme
+  bucket: changeme
+  credentials: changeme
+
+image:
+  repository: gcr.io/heptio-images/ark
+  tag: v0.6.0
+  pullPolicy: IfNotPresent
+
+secret:
+  name: cloud-credentials
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/contribution/ark-server/values.yaml
+++ b/contribution/ark-server/values.yaml
@@ -22,6 +22,20 @@ service:
   type: ClusterIP
   port: 80
 
+
+
+rbac:
+  create: true
+
+serviceAccount:
+  deploy:
+    create: true
+    name: deploy-ark
+  server:
+    create: true
+    name: heptio-ark
+
+
 ingress:
   enabled: false
   annotations: {}


### PR DESCRIPTION
## Premise
Helm cannot handle properly CRD becauses it has a validation mechanism that checks the installation before the CRD are actually created,
hence each resource that uses a CRD cannot be validated because the CRD doesn't exist yet!

## Solution
The solution here is to create CRD via helm chart, and only after (using a `post-install`) to install the resources with a container.
The container has the only job to execute a `kubectl create -f filename` and create the resources.

At the same time the resources created with the hook are completely transparent to Helm, that is, when you delete the
chart those resources remain there. Hence we need a sencond hook for deleting them (see delete.yaml)


