### PR TITLE
Ibm object storage

### DIFF
--- a/docs/cloud-common.md
+++ b/docs/cloud-common.md
@@ -7,6 +7,7 @@ The Ark repository includes a set of example YAML files that specify the setting
 * [Run Ark on AWS][0]
 * [Run Ark on GCP][1]
 * [Run Ark on Azure][2]
+* [Use IBM Cloud Object Store as Ark's storage destination][4]
 
 ## Examples
 
@@ -74,4 +75,5 @@ After you set up the Ark server, try these examples:
 [1]: gcp-config.md
 [2]: azure-config.md
 [3]: namespace.md
+[4]: ibm-config.md
 [19]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reclaiming

--- a/docs/ibm-config.md
+++ b/docs/ibm-config.md
@@ -1,0 +1,82 @@
+# Use IBM Cloud Object Storage as Ark's storage destination.
+You can deploy Ark on IBM [Public][5] or [Private][4] clouds, or even on any other Kubernetes cluster, but anyway you can use IBM Cloud Object Store as a destination for Ark's backups. 
+
+To set up IBM Cloud Object Storage (COS) as Ark's destination, you:
+
+* Create your COS instance 
+* Create an S3 bucket
+* Define a service that can store data in the bucket
+* Configure and start the Ark server
+
+
+## Create COS instance
+If you don’t have a COS instance, you can create a new one, according to the detailed instructions in [Creating a new resource instance][1].
+
+## Create an S3 bucket
+Heptio Ark requires an object storage bucket to store backups in. See instructions in [Create some buckets to store your data][2].
+
+## Define a service that can store data in the bucket. 
+The process of creating service credentials is described in [Service credentials][3]. 
+Several comments:
+
+1. The Ark service will write its backup into the bucket, so it requires the “Writer” access role.
+
+2. Ark uses an AWS S3 compatible API. Which means it authenticates using a signature created from a pair of access and secret keys — a set of HMAC credentials. You can create these HMAC credentials by specifying `{“HMAC”:true}` as an optional inline parameter. See step 3 in the [Service credentials][3] guide.
+
+3. After successfully creating a Service credential, you can view the JSON definition of the credential. Under the `cos_hmac_keys` entry there are `access_key_id` and `secret_access_key`. We will use them in the next step.
+
+4. Create an Ark-specific credentials file (`credentials-ark`) in your local directory:
+
+    ```
+    [default]
+    aws_access_key_id=<ACCESS_KEY_ID>
+    aws_secret_access_key=<SECRET_ACCESS_KEY>
+    ```
+
+    where the access key id and secret are the values that we got above.
+
+## Credentials and configuration
+
+In the Ark root directory, run the following to first set up namespaces, RBAC, and other scaffolding. To run in a custom namespace, make sure that you have edited the YAML files to specify the namespace. See [Run in custom namespace][0].
+
+```bash
+kubectl apply -f examples/common/00-prereqs.yaml
+```
+
+Create a Secret. In the directory of the credentials file you just created, run:
+
+```bash
+kubectl create secret generic cloud-credentials \
+    --namespace <ARK_SERVER_NAMESPACE> \
+    --from-file cloud=credentials-ark
+```
+
+Specify the following values in the example files:
+
+* In `examples/ibm/00-ark-config.yaml`:
+
+  * Replace `<YOUR_BUCKET>`, `<YOUR_REGION>` and `<YOUR_URL_ACCESS_POINT>`. See the [Config definition][6] for details.
+
+
+
+* (Optional) If you run the nginx example, in file `examples/nginx-app/with-pv.yaml`:
+
+    * Replace `<YOUR_STORAGE_CLASS_NAME>` with your `StorageClass` name.
+
+## Start the Ark server
+
+In the root of your Ark directory, run:
+
+  ```bash
+  kubectl apply -f examples/ibm/00-ark-config.yaml
+  kubectl apply -f examples/common/10-deployment.yaml
+  ```
+
+  [0]: namespace.md
+  [1]: https://console.bluemix.net/docs/services/cloud-object-storage/basics/order-storage.html#creating-a-new-resource-instance
+  [2]: https://console.bluemix.net/docs/services/cloud-object-storage/getting-started.html#create-buckets
+  [3]: https://console.bluemix.net/docs/services/cloud-object-storage/iam/service-credentials.html#service-credentials
+  [4]: https://www.ibm.com/support/knowledgecenter/SSBS6K_2.1.0/kc_welcome_containers.html
+  [5]: https://console.bluemix.net/docs/containers/container_index.html#container_index
+  [6]: config-definition.md#aws
+  [14]: http://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html

--- a/docs/namespace.md
+++ b/docs/namespace.md
@@ -52,6 +52,12 @@ For Azure, edit:
 * `https://github.com/heptio/ark/blob/master/examples/azure/00-ark-deployment.yaml`
 * `https://github.com/heptio/ark/blob/master/examples/azure/10-ark-config.yaml`
 
+### IBM
+
+For IBM, edit:
+
+* `https://github.com/heptio/ark/blob/master/examples/common/10-deployment.yaml`
+* `https://github.com/heptio/ark/blob/master/examples/ibm/00-ark-config.yaml`
 
 ## Specify the namespace in client commands
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ The YAML config files in this directory can be used to quickly deploy a containe
 
 * `minio/`: Used in the [Quickstart][1] to set up [Minio][0], a local S3-compatible object storage service. It provides a convenient way to test Ark without tying you to a specific cloud provider.
 
-* `aws/`, `azure/`, `gcp/`: Contains manifests specific to the given cloud provider's setup.
+* `aws/`, `azure/`, `gcp/`, `ibm/`: Contains manifests specific to the given cloud provider's setup.
 
 [0]: https://github.com/minio/minio
 [1]: /README.md#quickstart

--- a/examples/ibm/00-ark-config.yaml
+++ b/examples/ibm/00-ark-config.yaml
@@ -1,0 +1,31 @@
+# Copyright 2018 the Heptio Ark contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: ark.heptio.com/v1
+kind: Config
+metadata:
+  namespace: heptio-ark
+  name: default
+backupStorageProvider:
+  name: aws
+  bucket: <YOUR_BUCKET>
+  config:
+    region: <YOUR_REGION>
+    s3ForcePathStyle: "true"
+    s3Url:  <YOUR_URL_ACCESS_POINT>
+backupSyncPeriod: 30m
+gcSyncPeriod: 30m
+scheduleSyncPeriod: 1m
+---


### PR DESCRIPTION
Add a configuration option to use IBM Cloud Object Storage as Ark's backups destination. 