### PR TITLE
fix syntax for doc paths on GH

### DIFF
--- a/docs/aws-config.md
+++ b/docs/aws-config.md
@@ -117,6 +117,6 @@ In the root of your Ark directory, run:
   kubectl apply -f examples/common/10-deployment.yaml
   ```
 
-  [0]: /namespace.md
-  [6]: /config-definition.md#aws
+  [0]: namespace.md
+  [6]: config-definition.md#aws
   [14]: http://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html

--- a/docs/azure-config.md
+++ b/docs/azure-config.md
@@ -167,7 +167,7 @@ In the root of your Ark directory, run:
   kubectl apply -f examples/azure/
   ```
 
-  [0]: /namespace.md
+  [0]: namespace.md
   [8]: config-definition.md#azure
   [17]: https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-application-objects
   [18]: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli

--- a/docs/build-from-scratch.md
+++ b/docs/build-from-scratch.md
@@ -111,10 +111,10 @@ If you need to add or update the vendored dependencies, see [Vendoring dependenc
 [5]: https://golang.org/doc/install
 [6]: https://github.com/heptio/ark/tree/master/examples
 [7]: #run
-[8]: /config-definition.md
-[9]: /cloud-common.md
+[8]: config-definition.md
+[9]: cloud-common.md
 [10]: #vendoring-dependencies
-[11]: /vendoring-dependencies.md
+[11]: vendoring-dependencies.md
 [12]: #test
 [13]: https://github.com/heptio/ark/blob/master/hack/generate-proto.sh
 [14]: https://grpc.io/docs/quickstart/go.html#install-protocol-buffers-v3

--- a/docs/cloud-common.md
+++ b/docs/cloud-common.md
@@ -70,8 +70,8 @@ After you set up the Ark server, try these examples:
     ark restore create nginx-backup
     ```
 
-[0]: /docs/aws-config.md
-[1]: /docs/gcp-config.md
-[2]: /docs/azure-config.md
-[3]: /docs/namespace.md
+[0]: aws-config.md
+[1]: gcp-config.md
+[2]: azure-config.md
+[3]: namespace.md
 [19]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reclaiming

--- a/docs/extend.md
+++ b/docs/extend.md
@@ -5,5 +5,5 @@ Ark includes mechanisms for extending the core functionality to meet your indivi
 * [Hooks][27] allow you to specify commands to be executed within running pods during a backup. This is useful if you need to run a workload-specific command prior to taking a backup (for example, to flush disk buffers or to freeze a database).
 * [Plugins][28] allow you to develop custom object/block storage back-ends or per-item backup/restore actions that can execute arbitrary logic, including modifying the items being backed up/restored. Plugins can be used by Ark without needing to be compiled into the core Ark binary.
 
-[27]: /hooks.md
-[28]: /plugins.md
+[27]: hooks.md
+[28]: plugins.md

--- a/docs/gcp-config.md
+++ b/docs/gcp-config.md
@@ -101,8 +101,8 @@ In the root of your Ark directory, run:
   kubectl apply -f examples/common/10-deployment.yaml
   ```
 
-  [0]: /namespace.md
-  [7]: /config-definition.md#gcp
+  [0]: namespace.md
+  [7]: config-definition.md#gcp
   [15]: https://cloud.google.com/compute/docs/access/service-accounts
   [16]: https://cloud.google.com/sdk/docs/
   [22]: https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#prerequisites_for_using_role-based_access_control

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,7 +6,7 @@ These tips can help you troubleshoot known issues. If they don't help, you can [
 
 * [Debug restores][1]
 
-[0]: /docs/debugging-deletes.md
-[1]: /docs/debugging-restores.md
+[0]: debugging-deletes.md
+[1]: debugging-restores.md
 [4]: https://github.com/heptio/ark/issues
 [25]: http://slack.kubernetes.io/

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -50,4 +50,4 @@ ark restore create <BACKUP-NAME>
 
 [0]: #disaster-recovery
 [1]: #cluster-migration
-[3]: /config-definition.md#main-config-parameters
+[3]: config-definition.md#main-config-parameters


### PR DESCRIPTION
Signed-off-by: JENNIFER RONDEAU <jrondeau@heptio.com>

This PR does ONLY THE FOLLOWING:
fixes paths so that they link properly on  GitHub and the docs site