### PR TITLE
Run ark server locally

### DIFF
--- a/docs/cli-reference/ark_server.md
+++ b/docs/cli-reference/ark_server.md
@@ -14,8 +14,9 @@ ark server [flags]
 ### Options
 
 ```
-  -h, --help        help for server
-      --log-level   the level at which to log. Valid values are debug, info, warning, error, fatal, panic. (default info)
+  -h, --help                help for server
+      --log-level           the level at which to log. Valid values are debug, info, warning, error, fatal, panic. (default info)
+      --plugin-dir string   directory containing Ark plugins (default "/plugins")
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -65,6 +65,7 @@ func NewCommand() *cobra.Command {
 	var (
 		sortedLogLevels = getSortedLogLevels()
 		logLevelFlag    = flag.NewEnum(logrus.InfoLevel.String(), sortedLogLevels...)
+		pluginDir       = "/plugins"
 	)
 
 	var command = &cobra.Command{
@@ -101,7 +102,7 @@ func NewCommand() *cobra.Command {
 			}
 			namespace := getServerNamespace(namespaceFlag)
 
-			s, err := newServer(namespace, fmt.Sprintf("%s-%s", c.Parent().Name(), c.Name()), logger)
+			s, err := newServer(namespace, fmt.Sprintf("%s-%s", c.Parent().Name(), c.Name()), pluginDir, logger)
 
 			cmd.CheckError(err)
 
@@ -110,6 +111,7 @@ func NewCommand() *cobra.Command {
 	}
 
 	command.Flags().Var(logLevelFlag, "log-level", fmt.Sprintf("the level at which to log. Valid values are %s.", strings.Join(sortedLogLevels, ", ")))
+	command.Flags().StringVar(&pluginDir, "plugin-dir", pluginDir, "directory containing Ark plugins")
 
 	return command
 }
@@ -175,7 +177,7 @@ type server struct {
 	pluginManager         plugin.Manager
 }
 
-func newServer(namespace, baseName string, logger *logrus.Logger) (*server, error) {
+func newServer(namespace, baseName, pluginDir string, logger *logrus.Logger) (*server, error) {
 	clientConfig, err := client.Config("", "", baseName)
 	if err != nil {
 		return nil, err
@@ -191,7 +193,7 @@ func newServer(namespace, baseName string, logger *logrus.Logger) (*server, erro
 		return nil, errors.WithStack(err)
 	}
 
-	pluginManager, err := plugin.NewManager(logger, logger.Level)
+	pluginManager, err := plugin.NewManager(logger, logger.Level, pluginDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -176,16 +176,18 @@ func getPluginInstance(client *plugin.Client, kind PluginKind) (interface{}, err
 }
 
 func (m *manager) registerPlugins() error {
+	arkCommand := os.Args[0]
+
 	// first, register internal plugins
 	for _, provider := range []string{"aws", "gcp", "azure"} {
-		m.pluginRegistry.register(provider, "/ark", []string{"run-plugin", "cloudprovider", provider}, PluginKindObjectStore, PluginKindBlockStore)
+		m.pluginRegistry.register(provider, arkCommand, []string{"run-plugin", "cloudprovider", provider}, PluginKindObjectStore, PluginKindBlockStore)
 	}
-	m.pluginRegistry.register("pv", "/ark", []string{"run-plugin", string(PluginKindBackupItemAction), "pv"}, PluginKindBackupItemAction)
-	m.pluginRegistry.register("backup-pod", "/ark", []string{"run-plugin", string(PluginKindBackupItemAction), "pod"}, PluginKindBackupItemAction)
+	m.pluginRegistry.register("pv", arkCommand, []string{"run-plugin", string(PluginKindBackupItemAction), "pv"}, PluginKindBackupItemAction)
+	m.pluginRegistry.register("backup-pod", arkCommand, []string{"run-plugin", string(PluginKindBackupItemAction), "pod"}, PluginKindBackupItemAction)
 
-	m.pluginRegistry.register("job", "/ark", []string{"run-plugin", string(PluginKindRestoreItemAction), "job"}, PluginKindRestoreItemAction)
-	m.pluginRegistry.register("restore-pod", "/ark", []string{"run-plugin", string(PluginKindRestoreItemAction), "pod"}, PluginKindRestoreItemAction)
-	m.pluginRegistry.register("svc", "/ark", []string{"run-plugin", string(PluginKindRestoreItemAction), "svc"}, PluginKindRestoreItemAction)
+	m.pluginRegistry.register("job", arkCommand, []string{"run-plugin", string(PluginKindRestoreItemAction), "job"}, PluginKindRestoreItemAction)
+	m.pluginRegistry.register("restore-pod", arkCommand, []string{"run-plugin", string(PluginKindRestoreItemAction), "pod"}, PluginKindRestoreItemAction)
+	m.pluginRegistry.register("svc", arkCommand, []string{"run-plugin", string(PluginKindRestoreItemAction), "svc"}, PluginKindRestoreItemAction)
 
 	// second, register external plugins (these will override internal plugins, if applicable)
 	if _, err := os.Stat(pluginDir); err != nil {


### PR DESCRIPTION
If you want to test changes to the ark server without having to rebuild
and redeploy the ark container, this change allows you to do something
like this (assuming you've created your cloud credentials file):

AWS_SHARED_CREDENTIALS_FILE=credentials-minio ark server -n heptio-ark

Also added a `--plugin-dir` flag so you can test plugins locally too.