### PR TITLE
Remove Azure location requirement

### DIFF
--- a/docs/azure-config.md
+++ b/docs/azure-config.md
@@ -87,7 +87,7 @@ To integrate Ark with Azure, you must create an Ark-specific [service principal]
     az group list --query '[].{ ResourceGroup: name, Location:location }'
     ```
 
-    Get your cluster's Resource Group name from the `ResourceGroup` value in the response, and use it to set `$AZURE_RESOURCE_GROUP`. (Also note the `Location` value in the response -- this is later used in the Azure-specific portion of the Ark Config).
+    Get your cluster's Resource Group name from the `ResourceGroup` value in the response, and use it to set `$AZURE_RESOURCE_GROUP`.
 
 1. Create a service principal with `Contributor` role. This will have subscription-wide access, so protect this credential. You can specify a password or let the `az ad sp create-for-rbac` command create one for you.
 
@@ -129,7 +129,7 @@ Now that you have your Azure credentials stored in a Secret, you need to replace
 
 * In file `examples/azure/10-ark-config.yaml`:
 
-  * Replace `<YOUR_BUCKET>`, `<YOUR_LOCATION>`, and `<YOUR_TIMEOUT>`. See the [Config definition][8] for details.
+  * Replace `<YOUR_BUCKET>` and `<YOUR_TIMEOUT>`. See the [Config definition][8] for details.
 
 Here is an example of a completed file.
 
@@ -142,7 +142,6 @@ metadata:
 persistentVolumeProvider:
   name: azure
   config:
-    location: "West US"
     apiTimeout: 15m
 backupStorageProvider:
   name: azure
@@ -151,12 +150,6 @@ backupSyncPeriod: 30m
 gcSyncPeriod: 30m
 scheduleSyncPeriod: 1m
 restoreOnlyMode: false
-```
-
-You can get a complete list of Azure locations with the following command:
-
-```bash
-az account list-locations --query "sort([].displayName)" -o tsv
 ```
 
 ## Start the server

--- a/docs/config-definition.md
+++ b/docs/config-definition.md
@@ -98,17 +98,14 @@ No parameters required.
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `location` | string | Required Field | *Example*: "Canada East"<br><br>See [the list of available locations][5] (note that this particular page refers to them as "Regions"). |
 | `apiTimeout` | metav1.Duration | 2m0s | How long to wait for an Azure API request to complete before timeout. |
 
 [0]: #aws
 [1]: #gcp
 [2]: #azure
 [3]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
-[5]: https://azure.microsoft.com/en-us/regions/
 [6]: #parameter-reference
 [7]: #main-config-parameters
 [8]: #overview
 [9]: #example
 [10]: http://docs.aws.amazon.com/kms/latest/developerguide/overview.html
-

--- a/examples/azure/10-ark-config.yaml
+++ b/examples/azure/10-ark-config.yaml
@@ -21,7 +21,6 @@ metadata:
 persistentVolumeProvider:
   name: azure
   config:
-    location: <YOUR_LOCATION>
     apiTimeout: <YOUR_TIMEOUT>
 backupStorageProvider:
   name: azure


### PR DESCRIPTION
Instead of requiring the Ark admin to specify a "location" in the azure
persistentVolumeProvider config (meaning only a single location is
supported), get info about the disk (for its location) when creating a
snapshot, and get info about the snapshot (for its location) when
creating a disk from a snapshot.

Signed-off-by: Andy Goldstein <andy.goldstein@gmail.com>