### PR TITLE
extract GCP project ID from creds file, remove from config

### DIFF
--- a/docs/config-definition.md
+++ b/docs/config-definition.md
@@ -86,9 +86,7 @@ No parameters required.
 
 #### persistentVolumeProvider/config
 
-| Key | Type | Default | Meaning |
-| --- | --- | --- | --- |
-| `project` | string | Required Field | *Example*: "project-example-3jsn23"<br><br> See the [Project ID documentation][4] for details. |
+No parameters required.
 
 ### Azure
 
@@ -107,7 +105,6 @@ No parameters required.
 [1]: #gcp
 [2]: #azure
 [3]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
-[4]: https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects
 [5]: https://azure.microsoft.com/en-us/regions/
 [6]: #parameter-reference
 [7]: #main-config-parameters

--- a/docs/gcp-config.md
+++ b/docs/gcp-config.md
@@ -82,7 +82,7 @@ Specify the following values in the example files:
 
 * In file `examples/gcp/00-ark-config.yaml`:
 
-  * Replace `<YOUR_BUCKET>` and `<YOUR_PROJECT>`. See the [Config definition][7] for details.
+  * Replace `<YOUR_BUCKET>`. See the [Config definition][7] for details.
 
 * In file `examples/common/10-deployment.yaml`:
 

--- a/examples/gcp/00-ark-config.yaml
+++ b/examples/gcp/00-ark-config.yaml
@@ -20,8 +20,6 @@ metadata:
   name: default
 persistentVolumeProvider:
   name: gcp
-  config:
-    project: <YOUR_PROJECT>
 backupStorageProvider:
   name: gcp
   bucket: <YOUR_BUCKET>


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

As discussed this AM - this pulls the project ID from the (required) credentials file rather than requiring it to be provided in the config. I used this code in diluvian.