### PR TITLE
Azure: reduce client polling interval from default 60s to 5s

### DIFF
--- a/pkg/cloudprovider/azure/block_store.go
+++ b/pkg/cloudprovider/azure/block_store.go
@@ -102,6 +102,9 @@ func (b *blockStore) Init(config map[string]string) error {
 	disksClient := disk.NewDisksClient(cfg[azureSubscriptionIDKey])
 	snapsClient := disk.NewSnapshotsClient(cfg[azureSubscriptionIDKey])
 
+	disksClient.PollingDelay = 5 * time.Second
+	snapsClient.PollingDelay = 5 * time.Second
+
 	authorizer := autorest.NewBearerAuthorizer(spt)
 	disksClient.Authorizer = authorizer
 	snapsClient.Authorizer = authorizer


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

The Azure go client defaults to a 60s polling interval to check for API call results.  This is a significant amount of time to wait for calls that don't take very long to return.  Lower this to five seconds for our snapshot/disk operations to improve performance.