### PR TITLE
Azure: fix bug preventing snapshot deletion

### DIFF
--- a/pkg/cloudprovider/azure/block_store.go
+++ b/pkg/cloudprovider/azure/block_store.go
@@ -233,12 +233,17 @@ func (b *blockStore) CreateSnapshot(volumeID, volumeAZ string, tags map[string]s
 }
 
 func (b *blockStore) DeleteSnapshot(snapshotID string) error {
+	snapshotInfo, err := parseFullSnapshotName(snapshotID)
+	if err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), b.apiTimeout)
 	defer cancel()
 
-	_, errChan := b.snaps.Delete(b.resourceGroup, snapshotID, ctx.Done())
+	_, errChan := b.snaps.Delete(snapshotInfo.resourceGroup, snapshotInfo.name, ctx.Done())
 
-	err := <-errChan
+	err = <-errChan
 
 	return errors.WithStack(err)
 }


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

In #356 I broke snapshot deletion for Azure because I was passing the full snapshot URI rather than just the name to the delete call. This fixes that bug.