### PR TITLE
Change minio volume to emptyDir from hostPath

### DIFF
--- a/examples/minio/00-minio-deployment.yaml
+++ b/examples/minio/00-minio-deployment.yaml
@@ -30,8 +30,7 @@ spec:
     spec:
       volumes:
       - name: storage
-        hostPath:
-          path: /tmp/minio
+        emptyDir: {}
       containers:
       - name: minio
         image: minio/minio:latest


### PR DESCRIPTION
This commit changes the type of volume mounted inside the minio pod
from hostPath to emptyDir. This is done because minio requires
at least 1Gi to start, but the default hostPath under /tmp in
minishift does not have enough capacity.

Fixes #382

Signed-off-by: Shubham <shubham@linux.com>