### PR TITLE
Fix typo: replace ; with :

### DIFF
--- a/pkg/cmd/util/downloadrequest/downloadrequest.go
+++ b/pkg/cmd/util/downloadrequest/downloadrequest.go
@@ -122,7 +122,7 @@ Loop:
 	if resp.StatusCode != http.StatusOK {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return errors.Wrapf(err, "request failed; unable to decode response body")
+			return errors.Wrapf(err, "request failed: unable to decode response body")
 		}
 
 		return errors.Errorf("request failed: %v", string(body))


### PR DESCRIPTION
This commit replaces a ; with a : in an error message