### PR TITLE
Introduce validation logic to `ark restore logs`

### DIFF
--- a/pkg/cmd/cli/restore/logs.go
+++ b/pkg/cmd/cli/restore/logs.go
@@ -22,10 +22,13 @@ import (
 
 	"github.com/spf13/cobra"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/heptio/ark/pkg/apis/ark/v1"
 	"github.com/heptio/ark/pkg/client"
 	"github.com/heptio/ark/pkg/cmd"
 	"github.com/heptio/ark/pkg/cmd/util/downloadrequest"
+	arkclient "github.com/heptio/ark/pkg/generated/clientset/versioned"
 )
 
 func NewLogsCommand(f client.Factory) *cobra.Command {
@@ -36,9 +39,11 @@ func NewLogsCommand(f client.Factory) *cobra.Command {
 		Short: "Get restore logs",
 		Args:  cobra.ExactArgs(1),
 		Run: func(c *cobra.Command, args []string) {
+			l := NewLogsOptions()
+			cmd.CheckError(l.Complete(args))
+			cmd.CheckError(l.Validate(f))
 			arkClient, err := f.Client()
 			cmd.CheckError(err)
-
 			err = downloadrequest.Stream(arkClient.ArkV1(), f.Namespace(), args[0], v1.DownloadTargetKindRestoreLog, os.Stdout, timeout)
 			cmd.CheckError(err)
 		},
@@ -47,4 +52,36 @@ func NewLogsCommand(f client.Factory) *cobra.Command {
 	c.Flags().DurationVar(&timeout, "timeout", timeout, "how long to wait to receive logs")
 
 	return c
+}
+
+// LogsOptions contains the fields required to retrieve logs of a restore
+type LogsOptions struct {
+	RestoreName string
+
+	client arkclient.Interface
+}
+
+// NewLogsOptions returns a new instance of LogsOptions
+func NewLogsOptions() *LogsOptions {
+	return &LogsOptions{}
+}
+
+// Complete fills in LogsOptions with the given parameters, like populating the
+// restore name from the input args
+func (l *LogsOptions) Complete(args []string) error {
+	l.RestoreName = args[0]
+	return nil
+}
+
+// Validate validates the LogsOptions against the cluster, like validating if
+// the given restore exists in the cluster or not
+func (l *LogsOptions) Validate(f client.Factory) error {
+	c, err := f.Client()
+	if err != nil {
+		return err
+	}
+	l.client = c
+
+	_, err = l.client.ArkV1().Restores(f.Namespace()).Get(l.RestoreName, metav1.GetOptions{})
+	return err
 }


### PR DESCRIPTION
This commit introduces validation logic to `ark restore logs`
command, the way it already exists in other commands like `ark
restore create`.

Before the logs for a restore are fetched from the server, the
server is contacted to check if the specified restore exists. If
it does not, it errors out.

Fixes #389

Signed-off-by: Shubham <shubham@linux.com>