### PR TITLE
Add limitranges to defaultResourcePriorities

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -304,6 +304,7 @@ var defaultResourcePriorities = []string{
 	"secrets",
 	"configmaps",
 	"serviceaccounts",
+	"limitranges",
 }
 
 func applyConfigDefaults(c *api.Config, logger logrus.FieldLogger) {


### PR DESCRIPTION
This commit adds limitranges to defaultResourcePriorities as
suggested in #385.

This is done so that pods are not restored before the LimitRange
objects, because that would lead to pods not honoring the requests
and limits set in LimitRange objects.

Fixes #385