### PR TITLE
Merge serviceaccounts on restore

### DIFF
--- a/pkg/client/dynamic.go
+++ b/pkg/client/dynamic.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 )
@@ -82,12 +83,20 @@ type Getter interface {
 	Get(name string, opts metav1.GetOptions) (*unstructured.Unstructured, error)
 }
 
+// Patcher patches an object.
+type Patcher interface {
+	//Patch patches the named object using the provided patch bytes, which are expected to be in JSON merge patch format. The patched object is returned.
+
+	Patch(name string, data []byte) (*unstructured.Unstructured, error)
+}
+
 // Dynamic contains client methods that Ark needs for backing up and restoring resources.
 type Dynamic interface {
 	Creator
 	Lister
 	Watcher
 	Getter
+	Patcher
 }
 
 // dynamicResourceClient implements Dynamic.
@@ -111,4 +120,8 @@ func (d *dynamicResourceClient) Watch(options metav1.ListOptions) (watch.Interfa
 
 func (d *dynamicResourceClient) Get(name string, opts metav1.GetOptions) (*unstructured.Unstructured, error) {
 	return d.resourceClient.Get(name, opts)
+}
+
+func (d *dynamicResourceClient) Patch(name string, data []byte) (*unstructured.Unstructured, error) {
+	return d.resourceClient.Patch(name, types.MergePatchType, data)
 }

--- a/pkg/kuberesource/kuberesource.go
+++ b/pkg/kuberesource/kuberesource.go
@@ -28,4 +28,5 @@ var (
 	PersistentVolumeClaims = schema.GroupResource{Group: "", Resource: "persistentvolumeclaims"}
 	PersistentVolumes      = schema.GroupResource{Group: "", Resource: "persistentvolumes"}
 	Pods                   = schema.GroupResource{Group: "", Resource: "pods"}
+	ServiceAccounts        = schema.GroupResource{Group: "", Resource: "serviceaccounts"}
 )

--- a/pkg/restore/merge_service_account.go
+++ b/pkg/restore/merge_service_account.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2018 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package restore
+
+import (
+	"encoding/json"
+	"strings"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/pkg/errors"
+
+	corev1api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/heptio/ark/pkg/util/collections"
+)
+
+// mergeServiceAccount takes a backed up serviceaccount and merges attributes into the current in-cluster service account.
+// The default token secret from the backed up serviceaccount will be ignored in favor of the one already present.
+// Labels and Annotations on the backed up version but not on the in-cluster version will be merged. If a key is specified in both, the in-cluster version is retained.
+func mergeServiceAccounts(fromCluster, fromBackup *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	desired := new(corev1api.ServiceAccount)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(fromCluster.UnstructuredContent(), desired); err != nil {
+		return nil, errors.Wrap(err, "unable to convert from-cluster service account from unstructured to serviceaccount")
+
+	}
+
+	backupSA := new(corev1api.ServiceAccount)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(fromBackup.UnstructuredContent(), backupSA); err != nil {
+		return nil, errors.Wrap(err, "unable to convert from backed up service account unstructured to serviceaccount")
+	}
+
+	for i := len(backupSA.Secrets) - 1; i >= 0; i-- {
+		secret := &backupSA.Secrets[i]
+		if strings.HasPrefix(secret.Name, "default-token-") {
+			// Copy all secrets *except* default-token
+			backupSA.Secrets = append(backupSA.Secrets[:i], backupSA.Secrets[i+1:]...)
+			break
+		}
+	}
+
+	desired.Secrets = mergeObjectReferenceSlices(desired.Secrets, backupSA.Secrets)
+
+	desired.ImagePullSecrets = mergeLocalObjectReferenceSlices(desired.ImagePullSecrets, backupSA.ImagePullSecrets)
+
+	collections.MergeMaps(desired.Labels, backupSA.Labels)
+
+	collections.MergeMaps(desired.Annotations, backupSA.Annotations)
+
+	desiredUnstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(desired)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to convert desired service account to unstructured")
+	}
+	// The DefaultUnstructuredConverter.ToUnstructured function will populate the creation timestamp with the nil value
+	// However, we remove this on both the backup and cluster objects before comparison, and we don't want it in any patches.
+	delete(desiredUnstructured["metadata"].(map[string]interface{}), "creationTimestamp")
+
+	return &unstructured.Unstructured{Object: desiredUnstructured}, nil
+}
+
+func mergeObjectReferenceSlices(first, second []corev1api.ObjectReference) []corev1api.ObjectReference {
+	for _, s := range second {
+		var exists bool
+		for _, f := range first {
+			if s.Name == f.Name {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			first = append(first, s)
+		}
+	}
+
+	return first
+}
+
+func mergeLocalObjectReferenceSlices(first, second []corev1api.LocalObjectReference) []corev1api.LocalObjectReference {
+	for _, s := range second {
+		var exists bool
+		for _, f := range first {
+			if s.Name == f.Name {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			first = append(first, s)
+		}
+	}
+
+	return first
+}
+
+// generatePatch will calculate a JSON merge patch for an object's desired state.
+// If the passed in objects are already equal, nil is returned.
+func generatePatch(fromCluster, desired *unstructured.Unstructured) ([]byte, error) {
+	// If the objects are already equal, there's no need to generate a patch.
+	if equality.Semantic.DeepEqual(fromCluster, desired) {
+		return nil, nil
+	}
+
+	desiredBytes, err := json.Marshal(desired.Object)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to marshal desired object")
+	}
+
+	fromClusterBytes, err := json.Marshal(fromCluster.Object)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to marshal in-cluster object")
+	}
+
+	patchBytes, err := jsonpatch.CreateMergePatch(fromClusterBytes, desiredBytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create merge patch")
+	}
+
+	return patchBytes, nil
+}

--- a/pkg/restore/merge_service_account_test.go
+++ b/pkg/restore/merge_service_account_test.go
@@ -1,0 +1,693 @@
+/*
+Copyright 2018 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package restore
+
+import (
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/assert"
+
+	corev1api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	arktest "github.com/heptio/ark/pkg/util/test"
+)
+
+var mergedServiceAccountsBenchmarkResult *unstructured.Unstructured
+
+func BenchmarkMergeServiceAccountBasic(b *testing.B) {
+	tests := []struct {
+		name        string
+		fromCluster *unstructured.Unstructured
+		fromBackup  *unstructured.Unstructured
+	}{
+		{
+			name: "only default tokens present",
+			fromCluster: arktest.UnstructuredOrDie(
+				`{
+					"apiVersion": "v1",
+					"kind": "ServiceAccount",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default"
+					},
+					"secrets": [
+						{ "name": "default-token-abcde" }
+					]
+				}`,
+			),
+			fromBackup: arktest.UnstructuredOrDie(
+				`{
+					"kind": "ServiceAccount",
+					"apiVersion": "v1",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default"
+					},
+					"secrets": [
+						{ "name": "default-token-xzy12" }
+					]
+				}`,
+			),
+		},
+		{
+			name: "service accounts with multiple secrets",
+			fromCluster: arktest.UnstructuredOrDie(
+				`{
+					"apiVersion": "v1",
+					"kind": "ServiceAccount",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default"
+					},
+					"secrets": [
+						{ "name": "default-token-abcde" },
+						{ "name": "my-secret" },
+						{ "name": "sekrit" }
+					]
+				}`,
+			),
+
+			fromBackup: arktest.UnstructuredOrDie(
+				`{
+					"kind": "ServiceAccount",
+					"apiVersion": "v1",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default"
+					},
+					"secrets": [
+						{ "name": "default-token-xzy12" },
+						{ "name": "my-old-secret" },
+						{ "name": "secrete"}
+					]
+				}`,
+			),
+		},
+		{
+			name: "service accounts with labels and annotations",
+			fromCluster: arktest.UnstructuredOrDie(
+				`{
+					"apiVersion": "v1",
+					"kind": "ServiceAccount",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default",
+						"labels": {
+							"l1": "v1",
+							"l2": "v2",
+							"l3": "v3"
+						},
+						"annotations": {
+							"a1": "v1",
+							"a2": "v2",
+							"a3": "v3",
+							"a4": "v4"
+						}
+					},
+					"secrets": [
+						{ "name": "default-token-abcde" }
+					]
+				}`,
+			),
+
+			fromBackup: arktest.UnstructuredOrDie(
+				`{
+					"kind": "ServiceAccount",
+					"apiVersion": "v1",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default",
+						"labels": {
+							"l1": "v1",
+							"l2": "v2",
+							"l3": "v3",
+							"l4": "v4",
+							"l5": "v5"
+						},
+						"annotations": {
+							"a1": "v1",
+							"a2": "v2",
+							"a3": "v3",
+							"a4": "v4",
+							"a5": "v5",
+							"a6": "v6"
+						}
+					},
+					"secrets": [
+						{ "name": "default-token-xzy12" }
+					]
+				}`,
+			),
+		},
+	}
+
+	var desired *unstructured.Unstructured
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				desired, _ = mergeServiceAccounts(test.fromCluster, test.fromBackup)
+			}
+
+			mergedServiceAccountsBenchmarkResult = desired
+		})
+	}
+}
+
+func TestMergeLocalObjectReferenceSlices(t *testing.T) {
+	tests := []struct {
+		name     string
+		first    []corev1api.LocalObjectReference
+		second   []corev1api.LocalObjectReference
+		expected []corev1api.LocalObjectReference
+	}{
+		{
+			name: "two slices without overlapping elements",
+			first: []corev1api.LocalObjectReference{
+				{Name: "lor1"},
+				{Name: "lor2"},
+			},
+			second: []corev1api.LocalObjectReference{
+				{Name: "lor3"},
+				{Name: "lor4"},
+			},
+			expected: []corev1api.LocalObjectReference{
+				{Name: "lor1"},
+				{Name: "lor2"},
+				{Name: "lor3"},
+				{Name: "lor4"},
+			},
+		},
+		{
+			name: "two slices with an overlapping element",
+			first: []corev1api.LocalObjectReference{
+				{Name: "lor1"},
+				{Name: "lor2"},
+			},
+			second: []corev1api.LocalObjectReference{
+				{Name: "lor3"},
+				{Name: "lor2"},
+			},
+			expected: []corev1api.LocalObjectReference{
+				{Name: "lor1"},
+				{Name: "lor2"},
+				{Name: "lor3"},
+			},
+		},
+		{
+			name: "merging always adds elements to the end",
+			first: []corev1api.LocalObjectReference{
+				{Name: "lor3"},
+				{Name: "lor4"},
+			},
+			second: []corev1api.LocalObjectReference{
+				{Name: "lor1"},
+				{Name: "lor2"},
+			},
+			expected: []corev1api.LocalObjectReference{
+				{Name: "lor3"},
+				{Name: "lor4"},
+				{Name: "lor1"},
+				{Name: "lor2"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := mergeLocalObjectReferenceSlices(test.first, test.second)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestMergeObjectReferenceSlices(t *testing.T) {
+	tests := []struct {
+		name     string
+		first    []corev1api.ObjectReference
+		second   []corev1api.ObjectReference
+		expected []corev1api.ObjectReference
+	}{
+		{
+			name: "two slices without overlapping elements",
+			first: []corev1api.ObjectReference{
+				{Name: "or1"},
+				{Name: "or2"},
+			},
+			second: []corev1api.ObjectReference{
+				{Name: "or3"},
+				{Name: "or4"},
+			},
+			expected: []corev1api.ObjectReference{
+				{Name: "or1"},
+				{Name: "or2"},
+				{Name: "or3"},
+				{Name: "or4"},
+			},
+		},
+		{
+			name: "two slices with an overlapping element",
+			first: []corev1api.ObjectReference{
+				{Name: "or1"},
+				{Name: "or2"},
+			},
+			second: []corev1api.ObjectReference{
+				{Name: "or3"},
+				{Name: "or2"},
+			},
+			expected: []corev1api.ObjectReference{
+				{Name: "or1"},
+				{Name: "or2"},
+				{Name: "or3"},
+			},
+		},
+		{
+			name: "merging always adds elements to the end",
+			first: []corev1api.ObjectReference{
+				{Name: "or3"},
+				{Name: "or4"},
+			},
+			second: []corev1api.ObjectReference{
+				{Name: "or1"},
+				{Name: "or2"},
+			},
+			expected: []corev1api.ObjectReference{
+				{Name: "or3"},
+				{Name: "or4"},
+				{Name: "or1"},
+				{Name: "or2"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := mergeObjectReferenceSlices(test.first, test.second)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+// stripWhitespace removes any Unicode whitespace from a string.
+// Useful for cleaning up formatting on expected JSON strings before comparison
+func stripWhitespace(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return -1
+		}
+		return r
+	}, s)
+}
+
+func TestGeneratePatch(t *testing.T) {
+	tests := []struct {
+		name           string
+		fromCluster    *unstructured.Unstructured
+		desired        *unstructured.Unstructured
+		expectedString string
+		expectedErr    bool
+	}{
+		{
+			name: "objects are equal, no patch needed",
+			fromCluster: arktest.UnstructuredOrDie(
+				`{
+					"apiVersion": "v1",
+					"kind": "ServiceAccount",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default"
+					},
+					"secrets": [
+						{ "name": "default-token-abcde" }
+					]
+				}`,
+			),
+			desired: arktest.UnstructuredOrDie(
+				`{
+					"apiVersion": "v1",
+					"kind": "ServiceAccount",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default"
+					},
+					"secrets": [
+						{ "name": "default-token-abcde" }
+					]
+				}`,
+			),
+			expectedString: "",
+			expectedErr:    false,
+		},
+		{
+			name: "patch is required when labels are present",
+			fromCluster: arktest.UnstructuredOrDie(
+				`{
+					"apiVersion": "v1",
+					"kind": "ServiceAccount",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default"
+					},
+					"secrets": [
+						{ "name": "default-token-abcde" }
+					]
+				}`,
+			),
+			desired: arktest.UnstructuredOrDie(
+				`{
+					"apiVersion": "v1",
+					"kind": "ServiceAccount",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default",
+						"labels": {
+							"label1": "value1",
+							"label2": "value2"
+						}
+					},
+					"secrets": [
+						{ "name": "default-token-abcde" }
+					]
+				}`,
+			),
+			expectedString: stripWhitespace(
+				`{
+					"metadata": {
+						"labels": {
+							"label1":"value1",
+							"label2":"value2"
+						}
+					}
+				}`,
+			),
+			expectedErr: false,
+		},
+		{
+			name: "patch is required when annotations are present",
+			fromCluster: arktest.UnstructuredOrDie(
+				`{
+					"apiVersion": "v1",
+					"kind": "ServiceAccount",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default"
+					},
+					"secrets": [
+						{ "name": "default-token-abcde" }
+					]
+				}`,
+			),
+			desired: arktest.UnstructuredOrDie(
+				`{
+					"apiVersion": "v1",
+					"kind": "ServiceAccount",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default",
+						"annotations" :{
+							"a1": "v1",
+							"a2": "v2"
+						}
+					},
+					"secrets": [
+						{ "name": "default-token-abcde" }
+					]
+				}`,
+			),
+			expectedString: stripWhitespace(
+				`{
+					"metadata": {
+						"annotations": {
+							"a1":"v1",
+							"a2":"v2"
+						}
+					}
+				}`,
+			),
+			expectedErr: false,
+		},
+		{
+			name: "patch is required many secrets are present",
+			fromCluster: arktest.UnstructuredOrDie(
+				`{
+					"apiVersion": "v1",
+					"kind": "ServiceAccount",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default"
+					},
+					"secrets": [
+						{ "name": "default-token-abcde" }
+					]
+				}`,
+			),
+			desired: arktest.UnstructuredOrDie(
+				`{
+					"apiVersion": "v1",
+					"kind": "ServiceAccount",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default"
+					},
+					"secrets": [
+						{ "name": "default-token-abcde" },
+						{ "name": "sekrit" },
+						{ "name": "secrete" }
+					]
+				}`,
+			),
+			expectedString: stripWhitespace(
+				`{
+					"secrets": [
+						{"name": "default-token-abcde"},
+						{"name": "sekrit"},
+						{"name": "secrete"}
+					]
+				}`,
+			),
+			expectedErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := generatePatch(test.fromCluster, test.desired)
+			if assert.Equal(t, test.expectedErr, err != nil) {
+				assert.Equal(t, test.expectedString, string(result))
+			}
+		})
+	}
+}
+
+func TestMergeServiceAccountBasic(t *testing.T) {
+	tests := []struct {
+		name        string
+		fromCluster *unstructured.Unstructured
+		fromBackup  *unstructured.Unstructured
+		expectedRes *unstructured.Unstructured
+		expectedErr bool
+	}{
+		{
+			name: "only default tokens present",
+			fromCluster: arktest.UnstructuredOrDie(
+				`{
+					"apiVersion": "v1",
+					"kind": "ServiceAccount",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default"
+					},
+					"secrets": [
+						{ "name": "default-token-abcde" }
+					]
+				}`,
+			),
+			fromBackup: arktest.UnstructuredOrDie(
+				`{
+					"kind": "ServiceAccount",
+					"apiVersion": "v1",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default"
+					},
+					"secrets": [
+						{ "name": "default-token-xzy12" }
+					]
+				}`,
+			),
+			expectedRes: arktest.UnstructuredOrDie(
+				`{
+					"apiVersion": "v1",
+					"kind": "ServiceAccount",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default"
+					},
+					"secrets": [
+						{ "name": "default-token-abcde" }
+					]
+				}`,
+			),
+		},
+		{
+			name: "service accounts with multiple secrets",
+			fromCluster: arktest.UnstructuredOrDie(
+				`{
+					"apiVersion": "v1",
+					"kind": "ServiceAccount",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default"
+					},
+					"secrets": [
+						{ "name": "default-token-abcde" },
+						{ "name": "my-secret" },
+						{ "name": "sekrit" }
+					]
+				}`,
+			),
+
+			fromBackup: arktest.UnstructuredOrDie(
+				`{
+					"kind": "ServiceAccount",
+					"apiVersion": "v1",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default"
+					},
+					"secrets": [
+						{ "name": "default-token-xzy12" },
+						{ "name": "my-old-secret" },
+						{ "name": "secrete"}
+					]
+				}`,
+			),
+			expectedRes: arktest.UnstructuredOrDie(
+				`{
+					"apiVersion": "v1",
+					"kind": "ServiceAccount",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default"
+					},
+					"secrets": [
+						{ "name": "default-token-abcde" },
+						{ "name": "my-secret" },
+						{ "name": "sekrit" },
+						{ "name": "my-old-secret" },
+						{ "name": "secrete"}
+					]
+				}`,
+			),
+		},
+		{
+			name: "service accounts with labels and annotations",
+			fromCluster: arktest.UnstructuredOrDie(
+				`{
+					"apiVersion": "v1",
+					"kind": "ServiceAccount",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default",
+						"labels": {
+							"l1": "v1",
+							"l2": "v2",
+							"l3": "v3"
+						},
+						"annotations": {
+							"a1": "v1",
+							"a2": "v2",
+							"a3": "v3",
+							"a4": "v4"
+						}
+					},
+					"secrets": [
+						{ "name": "default-token-abcde" }
+					]
+				}`,
+			),
+
+			fromBackup: arktest.UnstructuredOrDie(
+				`{
+					"kind": "ServiceAccount",
+					"apiVersion": "v1",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default",
+						"labels": {
+							"l1": "v1",
+							"l2": "v2",
+							"l3": "v3",
+							"l4": "v4",
+							"l5": "v5"
+						},
+						"annotations": {
+							"a1": "v1",
+							"a2": "v2",
+							"a3": "v3",
+							"a4": "v4",
+							"a5": "v5",
+							"a6": "v6"
+						}
+					},
+					"secrets": [
+						{ "name": "default-token-xzy12" }
+					]
+				}`,
+			),
+			expectedRes: arktest.UnstructuredOrDie(
+				`{
+					"kind": "ServiceAccount",
+					"apiVersion": "v1",
+					"metadata": {
+						"namespace": "ns1",
+						"name": "default",
+						"labels": {
+							"l1": "v1",
+							"l2": "v2",
+							"l3": "v3",
+							"l4": "v4",
+							"l5": "v5"
+						},
+						"annotations": {
+							"a1": "v1",
+							"a2": "v2",
+							"a3": "v3",
+							"a4": "v4",
+							"a5": "v5",
+							"a6": "v6"
+						}
+					},
+					"secrets": [
+						{ "name": "default-token-abcde" }
+					]
+				}`,
+			),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(b *testing.T) {
+			result, err := mergeServiceAccounts(test.fromCluster, test.fromBackup)
+			if err != nil {
+				assert.Equal(t, test.expectedRes, result)
+			}
+		})
+	}
+}

--- a/pkg/util/collections/map_utils.go
+++ b/pkg/util/collections/map_utils.go
@@ -122,3 +122,14 @@ func Exists(root map[string]interface{}, path string) bool {
 	_, err := GetValue(root, path)
 	return err == nil
 }
+
+// MergeMaps takes two map[string]string and merges missing keys from the second into the first.
+// If a key already exists, its value is not overwritten.
+func MergeMaps(first, second map[string]string) {
+	for k, v := range second {
+		_, ok := first[k]
+		if !ok {
+			first[k] = v
+		}
+	}
+}

--- a/pkg/util/collections/map_utils_test.go
+++ b/pkg/util/collections/map_utils_test.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package collections
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestGetString(t *testing.T) {
 	var testCases = []struct {

--- a/pkg/util/test/fake_dynamic.go
+++ b/pkg/util/test/fake_dynamic.go
@@ -64,3 +64,8 @@ func (c *FakeDynamicClient) Get(name string, opts metav1.GetOptions) (*unstructu
 	args := c.Called(name, opts)
 	return args.Get(0).(*unstructured.Unstructured), args.Error(1)
 }
+
+func (c *FakeDynamicClient) Patch(name string, data []byte) (*unstructured.Unstructured, error) {
+	args := c.Called(name, data)
+	return args.Get(0).(*unstructured.Unstructured), args.Error(1)
+}


### PR DESCRIPTION
When a namespace is restored, Kubernetes creates a new default
serviceaccount before Ark processes the backed up one.

In order to retain information, copy the secrets, including image pull
secrets, over to the new, in-cluster service account.

Fixes #130