### PR TITLE
add helper function to compare slices of actions reliably and fix test flake

### DIFF
--- a/pkg/controller/backup_deletion_controller_test.go
+++ b/pkg/controller/backup_deletion_controller_test.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -431,32 +430,7 @@ func TestBackupDeletionControllerProcessRequest(t *testing.T) {
 			),
 		}
 
-		assert.Len(t, td.client.Actions(), len(expectedActions))
-		for _, e := range expectedActions {
-			found := false
-			for _, a := range td.client.Actions() {
-				if reflect.DeepEqual(e, a) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Errorf("missing expected action %#v", e)
-			}
-		}
-
-		for _, a := range td.client.Actions() {
-			found := false
-			for _, e := range expectedActions {
-				if reflect.DeepEqual(e, a) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Errorf("unexpected action %#v", a)
-			}
-		}
+		arktest.CompareActions(t, expectedActions, td.client.Actions())
 
 		// Make sure snapshot was deleted
 		assert.Equal(t, 0, td.snapshotService.SnapshotsTaken.Len())
@@ -604,8 +578,7 @@ func TestBackupDeletionControllerDeleteExpiredRequests(t *testing.T) {
 				expectedActions = append(expectedActions, core.NewDeleteAction(v1.SchemeGroupVersion.WithResource("deletebackuprequests"), "ns", name))
 			}
 
-			assert.Equal(t, expectedActions, client.Actions())
+			arktest.CompareActions(t, expectedActions, client.Actions())
 		})
-
 	}
 }

--- a/pkg/util/test/comparisons.go
+++ b/pkg/util/test/comparisons.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	core "k8s.io/client-go/testing"
+)
+
+// CompareActions checks slices of actual and expected Actions
+// for equality (ignoring order). It checks that the lengths of
+// the slices are the same, that each actual Action has a
+// corresponding expected Action, and that each expected Action
+// has a corresponding actual Action.
+func CompareActions(t *testing.T, expected, actual []core.Action) {
+	assert.Len(t, actual, len(expected))
+
+	for _, e := range expected {
+		found := false
+		for _, a := range actual {
+			if reflect.DeepEqual(e, a) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing expected action %#v", e)
+		}
+	}
+
+	for _, a := range actual {
+		found := false
+		for _, e := range expected {
+			if reflect.DeepEqual(e, a) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("unexpected action %#v", a)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

Fixes a unit test flake.