### PR TITLE
add nodeSelector so that ark server doesn't end up on a windows node …

### DIFF
--- a/examples/azure/00-ark-deployment.yaml
+++ b/examples/azure/00-ark-deployment.yaml
@@ -43,3 +43,5 @@ spec:
       volumes:
         - name: plugins
           emptyDir: {}
+      nodeSelector:
+        beta.kubernetes.io/os: linux


### PR DESCRIPTION
Add nodeSelector so that ark server doesn't end up on a windows node when running a hybrid cluster on Azure.

Signed-off-by: ffd2subroutine <ffd2subroutine@users.noreply.github.com>