### PR TITLE
use typed structs for decoding patch JSON in unit tests

### DIFF
--- a/pkg/util/collections/map_utils.go
+++ b/pkg/util/collections/map_utils.go
@@ -122,14 +122,3 @@ func Exists(root map[string]interface{}, path string) bool {
 	_, err := GetValue(root, path)
 	return err == nil
 }
-
-// HasKeyAndVal returns true if root[path] exists and the value
-// contained is equal to val, or false otherwise.
-func HasKeyAndVal(root map[string]interface{}, path string, val interface{}) bool {
-	valObj, err := GetValue(root, path)
-	if err != nil {
-		return false
-	}
-
-	return valObj == val
-}


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

As I was looking at moving the `hasKeyAndVal` func around as part of #413 I realized that the patch unit tests (which are the only thing that use this func) can be simplified by using typed structs for decoding the patches. Updated all of our tests. I think it's cleaner.