### PR TITLE
Add examples/common/10-deployment.yaml back

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ NOTE: Make sure to check out the appropriate version. We recommend that you chec
     ```bash
     kubectl apply -f examples/common/00-prereqs.yaml
     kubectl apply -f examples/minio/
-    kubectl apply -f examples/common/10-deployment.yaml
     ```
 
     NOTE: If you get an error about Config creation, wait for a minute, then run the commands again.

--- a/docs/namespace.md
+++ b/docs/namespace.md
@@ -33,7 +33,7 @@ For all cloud providers, edit `https://github.com/heptio/ark/blob/master/example
 
 For AWS, edit:
 
-* `https://github.com/heptio/ark/blob/master/examples/common/10-deployment.yaml`
+* `https://github.com/heptio/ark/blob/master/examples/aws/10-deployment.yaml`
 * `https://github.com/heptio/ark/blob/master/examples/aws/00-ark-config.yaml`
 
 
@@ -41,7 +41,7 @@ For AWS, edit:
 
 For GCP, edit:
 
-* `https://github.com/heptio/ark/blob/master/examples/common/10-deployment.yaml`
+* `https://github.com/heptio/ark/blob/master/examples/gcp/10-deployment.yaml`
 * `https://github.com/heptio/ark/blob/master/examples/gcp/00-ark-config.yaml`
 
 
@@ -56,7 +56,7 @@ For Azure, edit:
 
 For IBM, edit:
 
-* `https://github.com/heptio/ark/blob/master/examples/common/10-deployment.yaml`
+* `https://github.com/heptio/ark/blob/master/examples/ibm/10-deployment.yaml`
 * `https://github.com/heptio/ark/blob/master/examples/ibm/00-ark-config.yaml`
 
 ## Specify the namespace in client commands

--- a/examples/common/README.md
+++ b/examples/common/README.md
@@ -8,7 +8,3 @@ This file contains the prerequisites necessary to run the Ark server:
 - `ark` service account
 - RBAC rules to grant permissions to the `ark` service account
 - CRDs for the Ark-specific resources (Backup, Schedule, Restore, Config)
-
-## 10-deployment.yaml
-
-This deploys Ark and be used for AWS, GCP, and Minio. *Note that it cannot be used for Azure.*

--- a/examples/minio/20-ark-deployment.yaml
+++ b/examples/minio/20-ark-deployment.yaml
@@ -1,0 +1,50 @@
+# Copyright 2017 the Heptio Ark contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  namespace: heptio-ark
+  name: ark
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: ark
+    spec:
+      restartPolicy: Always
+      serviceAccountName: ark
+      containers:
+        - name: ark
+          image: gcr.io/heptio-images/ark:latest
+          command:
+            - /ark
+          args:
+            - server
+          volumeMounts:
+            - name: cloud-credentials
+              mountPath: /credentials
+            - name: plugins
+              mountPath: /plugins
+          env:
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /credentials/cloud
+      volumes:
+        - name: cloud-credentials
+          secret:
+            secretName: cloud-credentials
+        - name: plugins
+          emptyDir: {}


### PR DESCRIPTION
The changes in https://github.com/heptio/ark/commit/1db966bf3c128fb5e5482d99d2504a7fa5d4d0d8#diff-c31a634b9c201723f2478087620b10c5 removed examples/common/10-deployment.yaml, which is listed in
README.md to start the server  at -
https://github.com/heptio/ark#set-up-server

This commit adds that file back so that things still work.

Signed-off-by: Shubham <shubham@linux.com>