### PR TITLE
Remove deprecated method for pushing images to GCR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,11 +120,7 @@ container-name:
 
 push: .push-$(DOTFILE_IMAGE) push-name
 .push-$(DOTFILE_IMAGE): .container-$(DOTFILE_IMAGE)
-ifeq ($(findstring gcr.io,$(REGISTRY)),gcr.io)
-	@gcloud docker -- push $(IMAGE):$(VERSION)
-else
 	@docker push $(IMAGE):$(VERSION)
-endif
 	@docker images -q $(IMAGE):$(VERSION) > $@
 
 push-name:


### PR DESCRIPTION
This [method for pushing images is deprecated](https://cloud.google.com/container-registry/docs/support/deprecation-notices#wzxhzdk4wzxhzdk5_gcloud_docker_and_docker_clients_above_version_1803). Instead we use [`docker-credentials-gcr`](https://cloud.google.com/container-registry/docs/advanced-authentication). We can now rely on `docker push`.

Note this means users might also need to update their local environment, here are [instructions for doing so](https://github.com/GoogleCloudPlatform/docker-credential-gcr#installation-and-usage).

Signed-off-by: Curt Micol <asenchi@heptio.com>