### PR TITLE
docker tag and push :latest when building a git tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,11 @@ container-name:
 push: .push-$(DOTFILE_IMAGE) push-name
 .push-$(DOTFILE_IMAGE): .container-$(DOTFILE_IMAGE)
 	@docker push $(IMAGE):$(VERSION)
+	@if git describe --tags --exact-match >/dev/null 2>&1; \
+	then \
+		docker tag $(IMAGE):$(VERSION) $(IMAGE):latest; \
+		docker push $(IMAGE):latest; \
+	fi
 	@docker images -q $(IMAGE):$(VERSION) > $@
 
 push-name:


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

Since we're no longer using the Jenkins docker build/publish plugin, we need to tag and push `:latest` in our Makefile.

Ref. https://github.com/heptio/sonobuoy/blob/master/Makefile#L84-L92