### PR TITLE
add backwards-compatibility for azure snapshot ID

### DIFF
--- a/pkg/cloudprovider/azure/block_store_test.go
+++ b/pkg/cloudprovider/azure/block_store_test.go
@@ -90,20 +90,38 @@ func TestSetVolumeID(t *testing.T) {
 	assert.Equal(t, "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/disks/revised", actual)
 }
 
-func TestParseFullSnapshotName(t *testing.T) {
+// TODO(1.0) rename to TestParseFullSnapshotName, switch to testing
+// the `parseFullSnapshotName` function, and remove case for legacy
+// format
+func TestParseSnapshotName(t *testing.T) {
+	b := &blockStore{
+		subscription:  "default-sub",
+		resourceGroup: "default-rg",
+	}
+
 	// invalid name
 	fullName := "foo/bar"
-	_, err := parseFullSnapshotName(fullName)
+	_, err := b.parseSnapshotName(fullName)
 	assert.Error(t, err)
 
-	// valid name
+	// valid name (current format)
 	fullName = "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/snapshots/snap-1"
-	snap, err := parseFullSnapshotName(fullName)
+	snap, err := b.parseSnapshotName(fullName)
 	require.NoError(t, err)
 
 	assert.Equal(t, "sub-1", snap.subscription)
 	assert.Equal(t, "rg-1", snap.resourceGroup)
 	assert.Equal(t, "snap-1", snap.name)
+
+	// valid name (legacy format)
+	// TODO(1.0) remove this test case
+	fullName = "foobar"
+	snap, err = b.parseSnapshotName(fullName)
+	require.NoError(t, err)
+	assert.Equal(t, b.subscription, snap.subscription)
+	assert.Equal(t, b.resourceGroup, snap.resourceGroup)
+	assert.Equal(t, fullName, snap.name)
+
 }
 
 func TestGetComputeResourceName(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

Add support for reading the old Azure snapshot name format to make transition to v0.8 smoother.