### PR TITLE
azure: pass full snapshot name when restoring disk

### DIFF
--- a/pkg/cloudprovider/azure/block_store.go
+++ b/pkg/cloudprovider/azure/block_store.go
@@ -64,6 +64,10 @@ type snapshotIdentifier struct {
 	name          string
 }
 
+func (si *snapshotIdentifier) String() string {
+	return getComputeResourceName(si.subscription, si.resourceGroup, snapshotsResource, si.name)
+}
+
 func getConfig() map[string]string {
 	cfg := map[string]string{
 		azureClientIDKey:         "",
@@ -147,7 +151,7 @@ func (b *blockStore) CreateVolumeFromSnapshot(snapshotID, volumeType, volumeAZ s
 		Properties: &disk.Properties{
 			CreationData: &disk.CreationData{
 				CreateOption:     disk.Copy,
-				SourceResourceID: &snapshotID,
+				SourceResourceID: stringPtr(snapshotIdentifier.String()),
 			},
 			AccountType: disk.StorageAccountTypes(volumeType),
 		},


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

Pass the fully-qualified snapshot name to the Azure API when restoring a disk from a snapshot, regardless of which snapshot name format (legacy or fully-qualified) is stored in the Ark backup