### PR TITLE
AWS: remove region requirement from config for backupStorageProvider

### DIFF
--- a/docs/aws-config.md
+++ b/docs/aws-config.md
@@ -139,7 +139,7 @@ Specify the following values in the example files:
 
 * In `examples/aws/00-ark-config.yaml`:
 
-  * Replace `<YOUR_BUCKET>` and `<YOUR_REGION>`. See the [Config definition][6] for details.
+  * Replace `<YOUR_BUCKET>` and `<YOUR_REGION>` (for S3, region is optional and will be queried from the AWS S3 API if not provided). See the [Config definition][6] for details.
 
 * (Optional) If you run the nginx example, in file `examples/nginx-app/with-pv.yaml`:
 

--- a/docs/config-definition.md
+++ b/docs/config-definition.md
@@ -67,7 +67,7 @@ The configurable parameters are as follows:
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `region` | string | Required Field | *Example*: "us-east-1"<br><br>See [AWS documentation][3] for the full list. |
+| `region` | string | Empty | *Example*: "us-east-1"<br><br>See [AWS documentation][3] for the full list.<br><br>Queried from the AWS S3 API if not provided. |
 | `s3ForcePathStyle` | bool | `false` | Set this to `true` if you are using a local storage service like Minio. |
 | `s3Url` | string | Required field for non-AWS-hosted storage| *Example*: http://minio:9000<br><br>You can specify the AWS S3 URL here for explicitness, but Ark can already generate it from `region`, and `bucket`. This field is primarily for local storage services like Minio.|
 | `kmsKeyId` | string | Empty | *Example*: "502b409c-4da1-419f-a16e-eif453b3i49f" or "alias/`<KMS-Key-Alias-Name>`"<br><br>Specify an [AWS KMS key][10] id or alias to enable encryption of the backups stored in S3. Only works with AWS S3 and may require explicitly granting key usage rights.|

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -329,6 +329,15 @@ func applyConfigDefaults(c *api.Config, logger logrus.FieldLogger) {
 	} else {
 		logger.WithField("priorities", c.ResourcePriorities).Info("Using resource priorities from config")
 	}
+
+	if c.BackupStorageProvider.Config == nil {
+		c.BackupStorageProvider.Config = make(map[string]string)
+	}
+
+	// add the bucket name to the config map so that object stores can use
+	// it when initializing. The AWS object store uses this to determine the
+	// bucket's region when setting up its client.
+	c.BackupStorageProvider.Config["bucket"] = c.BackupStorageProvider.Bucket
 }
 
 // watchConfig adds an update event handler to the Config shared informer, invoking s.cancelFunc


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

I learned yesterday that we can do this! See https://docs.aws.amazon.com/sdk-for-go/api/service/s3/s3manager/#GetBucketRegion

I'm going to suggest leaving the examples/docs as-is for now so we don't get the usual slew of questions due to folks using master docs but an older Ark version.