### PR TITLE
upgrade to go 1.10 / alpine 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.9.x
+  - 1.10.x
 
 sudo: required
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.6
+FROM alpine:3.7
 
 MAINTAINER Andy Goldstein <andy@heptio.com>
 

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ shell: build-dirs build-image
 		-v "$$(pwd):/go/src/$(PKG)" \
 		-v "$$(pwd)/_output/bin:/output" \
 		-v "$$(pwd)/.go/std/$(GOOS)/$(GOARCH):/usr/local/go/pkg/$(GOOS)_$(GOARCH)_static" \
+		-v "$$(pwd)/.go/go-build:/.cache/go-build" \
 		-w /go/src/$(PKG) \
 		$(BUILDER_IMAGE) \
 		/bin/sh $(CMD)
@@ -171,7 +172,7 @@ tar-bin: build
 
 build-dirs:
 	@mkdir -p _output/bin/$(GOOS)/$(GOARCH)
-	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/$(GOOS)/$(GOARCH)
+	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/$(GOOS)/$(GOARCH) .go/go-build
 
 build-image:
 	cd hack/build-image && docker build -t $(BUILDER_IMAGE) .

--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.9-alpine3.6
+FROM golang:1.10-alpine3.7
 
 RUN apk add --update --no-cache git bash && \
     mkdir -p /go/src/k8s.io && \

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -61,7 +61,7 @@ if [[ "${GOOS}" = "windows" ]]; then
   OUTPUT="${OUTPUT}.exe"
 fi
 
-go build -i \
+go build \
     -o ${OUTPUT} \
     -installsuffix "static" \
     -ldflags "${LDFLAGS}" \

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -23,6 +23,5 @@ export CGO_ENABLED=0
 TARGETS=$(for d in "$@"; do echo ./$d/...; done)
 
 echo "Running tests:"
-go test -i -installsuffix "static" ${TARGETS}
 go test -installsuffix "static" -timeout 60s ${TARGETS}
 echo "Success!"


### PR DESCRIPTION
Also make use of the go 1.10 build & test cache (https://golang.org/cmd/go/#hdr-Build_and_test_caching)