### PR TITLE
Don't restore completed pods or jobs

### DIFF
--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -162,9 +162,6 @@ func (ib *defaultItemBackupper) backupItem(logger logrus.FieldLogger, obj runtim
 
 	log.Info("Backing up resource")
 
-	// Never save status
-	delete(obj.UnstructuredContent(), "status")
-
 	log.Debug("Executing pre hooks")
 	if err := ib.itemHookHandler.handleHooks(log, groupResource, obj, ib.resourceHooks, hookPhasePre); err != nil {
 		return err

--- a/pkg/util/kube/groupresource.go
+++ b/pkg/util/kube/groupresource.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2018 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var PodsGroupResource = schema.GroupResource{Group: "", Resource: "pods"}
+var JobsGroupResource = schema.GroupResource{Group: "batch", Resource: "jobs"}
+var NamespacesGroupResource = schema.GroupResource{Group: "", Resource: "namespaces"}


### PR DESCRIPTION
Phase 1 of #454.

Backs up jobs and pods for auditing purposes, but skips them on restoring.

Signed-off-by: Nolan Brubaker <nolan@heptio.com>