### PR TITLE
add image-tagging policy doc

### DIFF
--- a/docs/image-tagging.md
+++ b/docs/image-tagging.md
@@ -1,0 +1,21 @@
+# Image tagging policy
+
+This document describes Ark's image tagging policy.
+
+## Released versions
+
+`gcr.io/heptio-images/ark:<SemVer>`
+
+Ark follows the [Semantic Versioning](http://semver.org/) standard for releases. Each tag in the `github.com/heptio/ark` repository has a matching image, e.g. `gcr.io/heptio-images/ark:v0.8.0`.
+
+### Latest
+
+`gcr.io/heptio-images/ark:latest`
+
+The `latest` tag follows the most recently released version of Ark.
+
+## Development
+
+`gcr.io/heptio-images/ark:master`
+
+The `master` tag follows the latest commit to land on the `master` branch.


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

Fixes #198 

@Bradamant3 : I think it makes sense to add a link to this under the `More Information` section on the GH pages site.