### PR TITLE
add replicasets and daemonsets to cohabitating resources

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -73,6 +73,14 @@ func (i *itemKey) String() string {
 	return fmt.Sprintf("resource=%s,namespace=%s,name=%s", i.resource, i.namespace, i.name)
 }
 
+var cohabitatingResources = map[string]*cohabitatingResource{
+	"deployments":     newCohabitatingResource("deployments", "extensions", "apps"),
+	"daemonsets":      newCohabitatingResource("daemonsets", "extensions", "apps"),
+	"replicasets":     newCohabitatingResource("replicasets", "extensions", "apps"),
+	"networkpolicies": newCohabitatingResource("networkpolicies", "extensions", "networking.k8s.io"),
+	"events":          newCohabitatingResource("events", "", "events.k8s.io"),
+}
+
 // NewKubernetesBackupper creates a new kubernetesBackupper.
 func NewKubernetesBackupper(
 	discoveryHelper discovery.Helper,
@@ -229,12 +237,6 @@ func (kb *kubernetesBackupper) Backup(backup *api.Backup, backupFile, logFile io
 
 	backedUpItems := make(map[itemKey]struct{})
 	var errs []error
-
-	cohabitatingResources := map[string]*cohabitatingResource{
-		"deployments":     newCohabitatingResource("deployments", "extensions", "apps"),
-		"networkpolicies": newCohabitatingResource("networkpolicies", "extensions", "networking.k8s.io"),
-		"events":          newCohabitatingResource("events", "", "events.k8s.io"),
-	}
 
 	resolvedActions, err := resolveActions(actions, kb.discoveryHelper)
 	if err != nil {

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -524,12 +524,6 @@ func TestBackup(t *testing.T) {
 			groupBackupper := &mockGroupBackupper{}
 			defer groupBackupper.AssertExpectations(t)
 
-			cohabitatingResources := map[string]*cohabitatingResource{
-				"deployments":     newCohabitatingResource("deployments", "extensions", "apps"),
-				"networkpolicies": newCohabitatingResource("networkpolicies", "extensions", "networking.k8s.io"),
-				"events":          newCohabitatingResource("events", "", "events.k8s.io"),
-			}
-
 			groupBackupperFactory.On("newGroupBackupper",
 				mock.Anything, // log
 				test.backup,


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

ReplicaSets and DaemonSets also moved from extensions to apps. Add them to cohabitating resources so they don't get backed up twice.