### PR TITLE
shutdown gracefully on SIGINT/SIGTERM

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -21,10 +21,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"os/signal"
 	"reflect"
 	"sort"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/heptio/ark/pkg/buildinfo"
@@ -237,6 +240,8 @@ func (s *server) run() error {
 
 	s.watchConfig(originalConfig)
 
+	s.handleShutdownSignals()
+
 	if err := s.initBackupService(config); err != nil {
 		return err
 	}
@@ -362,6 +367,17 @@ func (s *server) watchConfig(config *api.Config) {
 			}
 		},
 	})
+}
+
+func (s *server) handleShutdownSignals() {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		sig := <-sigs
+		s.logger.Infof("Received signal %s, gracefully shutting down", sig)
+		s.cancelFunc()
+	}()
 }
 
 func (s *server) initBackupService(config *api.Config) error {

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -224,6 +224,9 @@ func newServer(namespace, baseName, pluginDir string, logger *logrus.Logger) (*s
 }
 
 func (s *server) run() error {
+	defer s.pluginManager.CleanupClients()
+	s.handleShutdownSignals()
+
 	if err := s.ensureArkNamespace(); err != nil {
 		return err
 	}
@@ -239,8 +242,6 @@ func (s *server) run() error {
 	applyConfigDefaults(config, s.logger)
 
 	s.watchConfig(originalConfig)
-
-	s.handleShutdownSignals()
 
 	if err := s.initBackupService(config); err != nil {
 		return err

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -415,3 +415,9 @@ func (_m *MockManager) GetObjectStore(name string) (cloudprovider.ObjectStore, e
 
 	return r0, r1
 }
+
+// CleanupClients provides a mock function
+func (_m *MockManager) CleanupClients() {
+	_ = _m.Called()
+	return
+}

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -44,6 +44,7 @@ func baseConfig() *plugin.ClientConfig {
 	return &plugin.ClientConfig{
 		HandshakeConfig:  Handshake,
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
+		Managed:          true,
 	}
 }
 
@@ -123,6 +124,9 @@ type Manager interface {
 	// CloseRestoreItemActions terminates the plugin sub-processes that
 	// are hosting RestoreItemAction plugins for the given restore name.
 	CloseRestoreItemActions(restoreName string) error
+
+	// CleanupClients kills all plugin subprocesses.
+	CleanupClients()
 }
 
 type manager struct {
@@ -410,4 +414,8 @@ func closeAll(store *clientStore, kind PluginKind, scope string) error {
 	store.deleteAll(kind, scope)
 
 	return nil
+}
+
+func (m *manager) CleanupClients() {
+	plugin.CleanupClients()
 }


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

Fixes #366 

Currently we don't handle these signals. Per https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods, SIGTERM is sent when terminating a pod, and SIGINT is sent if running the server locally (i.e. for development) and ctrl+c is pressed.