### PR TITLE
use new cohabitatingResources map for each backup

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -73,12 +73,14 @@ func (i *itemKey) String() string {
 	return fmt.Sprintf("resource=%s,namespace=%s,name=%s", i.resource, i.namespace, i.name)
 }
 
-var cohabitatingResources = map[string]*cohabitatingResource{
-	"deployments":     newCohabitatingResource("deployments", "extensions", "apps"),
-	"daemonsets":      newCohabitatingResource("daemonsets", "extensions", "apps"),
-	"replicasets":     newCohabitatingResource("replicasets", "extensions", "apps"),
-	"networkpolicies": newCohabitatingResource("networkpolicies", "extensions", "networking.k8s.io"),
-	"events":          newCohabitatingResource("events", "", "events.k8s.io"),
+func cohabitatingResources() map[string]*cohabitatingResource {
+	return map[string]*cohabitatingResource{
+		"deployments":     newCohabitatingResource("deployments", "extensions", "apps"),
+		"daemonsets":      newCohabitatingResource("daemonsets", "extensions", "apps"),
+		"replicasets":     newCohabitatingResource("replicasets", "extensions", "apps"),
+		"networkpolicies": newCohabitatingResource("networkpolicies", "extensions", "networking.k8s.io"),
+		"events":          newCohabitatingResource("events", "", "events.k8s.io"),
+	}
 }
 
 // NewKubernetesBackupper creates a new kubernetesBackupper.
@@ -252,7 +254,7 @@ func (kb *kubernetesBackupper) Backup(backup *api.Backup, backupFile, logFile io
 		kb.dynamicFactory,
 		kb.discoveryHelper,
 		backedUpItems,
-		cohabitatingResources,
+		cohabitatingResources(),
 		resolvedActions,
 		kb.podCommandExecutor,
 		tw,

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -533,7 +533,7 @@ func TestBackup(t *testing.T) {
 				dynamicFactory,
 				discoveryHelper,
 				map[itemKey]struct{}{}, // backedUpItems
-				cohabitatingResources,
+				cohabitatingResources(),
 				mock.Anything,
 				kb.podCommandExecutor,
 				mock.Anything, // tarWriter


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

Fixes bug I introduced in #482 where moving cohabitatingResources to a package-level var caused state about "seen" to be tracked across backups.