### PR TITLE
Filter on resources that support get & delete

### DIFF
--- a/pkg/discovery/helper.go
+++ b/pkg/discovery/helper.go
@@ -108,9 +108,7 @@ func (h *helper) Refresh() error {
 	}
 
 	h.resources = discovery.FilteredBy(
-		discovery.ResourcePredicateFunc(func(groupVersion string, r *metav1.APIResource) bool {
-			return discovery.SupportsAllVerbs{Verbs: []string{"list", "create"}}.Match(groupVersion, r)
-		}),
+		discovery.ResourcePredicateFunc(filterByVerbs),
 		preferredResources,
 	)
 
@@ -130,6 +128,10 @@ func (h *helper) Refresh() error {
 	}
 
 	return nil
+}
+
+func filterByVerbs(groupVersion string, r *metav1.APIResource) bool {
+	return discovery.SupportsAllVerbs{Verbs: []string{"list", "create", "get", "delete"}}.Match(groupVersion, r)
 }
 
 // sortResources sources resources by moving extensions to the end of the slice. The order of all

--- a/pkg/discovery/helper_test.go
+++ b/pkg/discovery/helper_test.go
@@ -84,3 +84,60 @@ func TestSortResources(t *testing.T) {
 		})
 	}
 }
+
+func TestFilteringByVerbs(t *testing.T) {
+	tests := []struct {
+		name         string
+		groupVersion string
+		res          *metav1.APIResource
+		expected     bool
+	}{
+		{
+			name:         "resource that supports list, create, get, delete",
+			groupVersion: "v1",
+			res: &metav1.APIResource{
+				Verbs: metav1.Verbs{"list", "create", "get", "delete"},
+			},
+			expected: true,
+		},
+		{
+			name:         "resource that supports list, create, get, delete in a different order",
+			groupVersion: "v1",
+			res: &metav1.APIResource{
+				Verbs: metav1.Verbs{"delete", "get", "create", "list"},
+			},
+			expected: true,
+		},
+		{
+			name:         "resource that supports list, create, get, delete, and more",
+			groupVersion: "v1",
+			res: &metav1.APIResource{
+				Verbs: metav1.Verbs{"list", "create", "get", "delete", "update", "patch", "deletecollection"},
+			},
+			expected: true,
+		},
+		{
+			name:         "resource that supports only list and create",
+			groupVersion: "v1",
+			res: &metav1.APIResource{
+				Verbs: metav1.Verbs{"list", "create"},
+			},
+			expected: false,
+		},
+		{
+			name:         "resource that supports only get and delete",
+			groupVersion: "v1",
+			res: &metav1.APIResource{
+				Verbs: metav1.Verbs{"get", "delete"},
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out := filterByVerbs(test.groupVersion, test.res)
+			assert.Equal(t, test.expected, out)
+		})
+	}
+}


### PR DESCRIPTION
Some resources use GET for listing, which resulted in errors.

Fixes #475 

Signed-off-by: Nolan Brubaker <nolan@heptio.com>