### PR TITLE
Add documentation on how to use a selector negation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ Make sure that you install somewhere in your `$PATH`.
     ark backup create nginx-backup --selector app=nginx
     ```
 
+   Alternatively if you want to backup all objects *except* those matching the label `backup=ignore` :
+
+   ```
+   ark backup create nginx-backup --selector '(backup notin ignore)'
+   ```
+
 1. Simulate a disaster:
 
     ```


### PR DESCRIPTION
This will help users use the `--selector` flag to selectively exclude objects from being backed up by ark

workaround for #404 until dedicated flags are implemented

Signed-off-by: Dhananjay Sathe <dhanajaysathe@gmail.com>