### PR TITLE
Run post-hooks even if backup actions fail

### DIFF
--- a/pkg/backup/item_backupper_test.go
+++ b/pkg/backup/item_backupper_test.go
@@ -378,10 +378,7 @@ func TestBackupItemNoSkips(t *testing.T) {
 
 			obj := &unstructured.Unstructured{Object: item}
 			itemHookHandler.On("handleHooks", mock.Anything, groupResource, obj, resourceHooks, hookPhasePre).Return(nil)
-			if test.snapshotError == nil && test.additionalItemError == nil {
-				// TODO: Remove if-clause when #511 is resolved.
-				itemHookHandler.On("handleHooks", mock.Anything, groupResource, obj, resourceHooks, hookPhasePost).Return(nil)
-			}
+			itemHookHandler.On("handleHooks", mock.Anything, groupResource, obj, resourceHooks, hookPhasePost).Return(nil)
 
 			for i, item := range test.customActionAdditionalItemIdentifiers {
 				if test.additionalItemError != nil && i > 0 {


### PR DESCRIPTION
Fixes #511 

This pulls all the action execution out into a new function (should there be matching changes in unit tests for this?), then ensures post-action hooks are run regardless of errors in the actions, and then returns any errors (including any in the post hook)