### PR TITLE
Fix selector syntax in backup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ Make sure that you install somewhere in your `$PATH`.
     ark backup create nginx-backup --selector app=nginx
     ```
 
-   Alternatively if you want to backup all objects *except* those matching the label `backup=ignore` :
+   Alternatively if you want to backup all objects *except* those matching the label `backup=ignore`:
 
    ```
-   ark backup create nginx-backup --selector '(backup notin ignore)'
+   ark backup create nginx-backup --selector 'backup notin (ignore)'
    ```
 
 1. Simulate a disaster:


### PR DESCRIPTION
If you run the current command in the README it fails due to bad syntax:

```
ark backup create nginx-backup --selector '(backup notin ignore)'
```
```
Error: invalid argument "(backup notin ignore)" for "-l, --selector" flag: couldn't parse the selector string "(backup notin ignore)": found '(', expected: !, identifier, or 'end of string'
```

This fixes the syntax so it works as expected:

```
ark backup create nginx-backup --selector 'backup notin (ignore)'
```
```
Backup request "nginx-backup" submitted successfully.                                                                                   │No resources found.
Run `ark backup describe nginx-backup` for more details.
```

(This is the syntax originally presented [here](https://github.com/heptio/ark/issues/404#issuecomment-389891133), the PR to add it to the README just had a typo.)