### PR TITLE
Dockerfile: move restic fetch before ark add so it can be cached

### DIFF
--- a/Dockerfile-ark.alpine
+++ b/Dockerfile-ark.alpine
@@ -18,13 +18,13 @@ MAINTAINER Andy Goldstein <andy@heptio.com>
 
 RUN apk add --no-cache ca-certificates
 
-ADD /bin/linux/amd64/ark /ark
-
 RUN apk add --update --no-cache bzip2 && \
     wget --quiet https://github.com/restic/restic/releases/download/v0.9.0/restic_0.9.0_linux_amd64.bz2 && \
     bunzip2 restic_0.9.0_linux_amd64.bz2 && \
     mv restic_0.9.0_linux_amd64 /restic && \
     chmod +x /restic
+
+ADD /bin/linux/amd64/ark /ark
 
 ADD /complete-restore.sh /complete-restore.sh
 


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

Current ordering means restic gets re-fetched every time the ark binary changes.