### PR TITLE
get rid of restore staging dir by backing up/restoring within volume dir

### DIFF
--- a/Dockerfile-ark.alpine
+++ b/Dockerfile-ark.alpine
@@ -18,7 +18,7 @@ MAINTAINER Andy Goldstein <andy@heptio.com>
 
 RUN apk add --no-cache ca-certificates
 
-RUN apk add --update --no-cache bzip2 rsync && \
+RUN apk add --update --no-cache bzip2 && \
     wget --quiet https://github.com/restic/restic/releases/download/v0.9.1/restic_0.9.1_linux_amd64.bz2 && \
     bunzip2 restic_0.9.1_linux_amd64.bz2 && \
     mv restic_0.9.1_linux_amd64 /restic && \

--- a/pkg/restic/command.go
+++ b/pkg/restic/command.go
@@ -24,23 +24,18 @@ import (
 
 // Command represents a restic command.
 type Command struct {
-	BaseName     string
 	Command      string
 	RepoPrefix   string
 	Repo         string
 	PasswordFile string
+	Dir          string
 	Args         []string
 	ExtraFlags   []string
 }
 
 // StringSlice returns the command as a slice of strings.
 func (c *Command) StringSlice() []string {
-	var res []string
-	if c.BaseName != "" {
-		res = append(res, c.BaseName)
-	} else {
-		res = append(res, "/restic")
-	}
+	res := []string{"/restic"}
 
 	res = append(res, c.Command, repoFlag(c.RepoPrefix, c.Repo))
 	if c.PasswordFile != "" {
@@ -60,7 +55,10 @@ func (c *Command) String() string {
 // Cmd returns an exec.Cmd for the command.
 func (c *Command) Cmd() *exec.Cmd {
 	parts := c.StringSlice()
-	return exec.Command(parts[0], parts[1:]...)
+	cmd := exec.Command(parts[0], parts[1:]...)
+	cmd.Dir = c.Dir
+
+	return cmd
 }
 
 func repoFlag(prefix, repo string) string {

--- a/pkg/restic/command_factory.go
+++ b/pkg/restic/command_factory.go
@@ -12,7 +12,8 @@ func BackupCommand(repoPrefix, repo, passwordFile, path string, tags map[string]
 		RepoPrefix:   repoPrefix,
 		Repo:         repo,
 		PasswordFile: passwordFile,
-		Args:         []string{path},
+		Dir:          path,
+		Args:         []string{"."},
 		ExtraFlags:   backupTagFlags(tags),
 	}
 }
@@ -26,14 +27,15 @@ func backupTagFlags(tags map[string]string) []string {
 }
 
 // RestoreCommand returns a Command for running a restic restore.
-func RestoreCommand(repoPrefix, repo, passwordFile, podUID, snapshotID string) *Command {
+func RestoreCommand(repoPrefix, repo, passwordFile, snapshotID, target string) *Command {
 	return &Command{
 		Command:      "restore",
 		RepoPrefix:   repoPrefix,
 		Repo:         repo,
 		PasswordFile: passwordFile,
+		Dir:          target,
 		Args:         []string{snapshotID},
-		ExtraFlags:   []string{fmt.Sprintf("--target=/restores/%s", podUID)},
+		ExtraFlags:   []string{"--target=."},
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

By running `restic backup` from within the volume's root directory, we can then `restic restore` directly into the volume root dir.

Also fixed a bug in the PVR controller, in the code that was checking if the restic initcontainer was running.