### PR TITLE
move restic binary into /usr/bin so it's in PATH

### DIFF
--- a/Dockerfile-ark.alpine
+++ b/Dockerfile-ark.alpine
@@ -21,8 +21,8 @@ RUN apk add --no-cache ca-certificates
 RUN apk add --update --no-cache bzip2 && \
     wget --quiet https://github.com/restic/restic/releases/download/v0.9.1/restic_0.9.1_linux_amd64.bz2 && \
     bunzip2 restic_0.9.1_linux_amd64.bz2 && \
-    mv restic_0.9.1_linux_amd64 /restic && \
-    chmod +x /restic
+    mv restic_0.9.1_linux_amd64 /usr/bin/restic && \
+    chmod +x /usr/bin/restic
 
 ADD /bin/linux/amd64/ark /ark
 

--- a/pkg/restic/command.go
+++ b/pkg/restic/command.go
@@ -35,7 +35,7 @@ type Command struct {
 
 // StringSlice returns the command as a slice of strings.
 func (c *Command) StringSlice() []string {
-	res := []string{"/restic"}
+	res := []string{"restic"}
 
 	res = append(res, c.Command, repoFlag(c.RepoPrefix, c.Repo))
 	if c.PasswordFile != "" {


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

This keeps local running of the Ark server easy - just requires restic to be in your local path.