### PR TITLE
restic: use HostToContainer mount prop. for host-pods volume

### DIFF
--- a/examples/aws/20-restic-daemonset.yaml
+++ b/examples/aws/20-restic-daemonset.yaml
@@ -51,6 +51,7 @@ spec:
               mountPath: /credentials
             - name: host-pods
               mountPath: /host_pods
+              mountPropagation: HostToContainer
             - name: scratch
               mountPath: /scratch
           env:

--- a/examples/azure/20-restic-daemonset.yaml
+++ b/examples/azure/20-restic-daemonset.yaml
@@ -46,6 +46,7 @@ spec:
           volumeMounts:
             - name: host-pods
               mountPath: /host_pods
+              mountPropagation: HostToContainer
             - name: scratch
               mountPath: /scratch
           envFrom:

--- a/examples/gcp/20-restic-daemonset.yaml
+++ b/examples/gcp/20-restic-daemonset.yaml
@@ -51,6 +51,7 @@ spec:
               mountPath: /credentials
             - name: host-pods
               mountPath: /host_pods
+              mountPropagation: HostToContainer
             - name: scratch
               mountPath: /scratch
           env:

--- a/examples/minio/30-restic-daemonset.yaml
+++ b/examples/minio/30-restic-daemonset.yaml
@@ -51,6 +51,7 @@ spec:
               mountPath: /credentials
             - name: host-pods
               mountPath: /host_pods
+              mountPropagation: HostToContainer
             - name: scratch
               mountPath: /scratch
           env:


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

Ref. https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation

This allows sub-mounts under the host_pods (/var/lib/kubelet/pods) mount to be propagated to our daemonset pods. This is required to access e.g. PVs that are mounted after our daemonset pod mounts /var/lib/kubelet/pods.