### PR TITLE
restic: if S3, get bucket's region up-front

### DIFF
--- a/pkg/cloudprovider/aws/helpers.go
+++ b/pkg/cloudprovider/aws/helpers.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+// GetBucketRegion returns the AWS region that a bucket is in, or an error
+// if the region cannot be determined.
+func GetBucketRegion(bucket string) (string, error) {
+	var region string
+
+	session, err := session.NewSession()
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	for _, partition := range endpoints.DefaultPartitions() {
+		for regionHint := range partition.Regions() {
+			region, _ = s3manager.GetBucketRegion(context.Background(), session, bucket, regionHint)
+
+			// we only need to try a single region hint per partition, so break after the first
+			break
+		}
+
+		if region != "" {
+			return region, nil
+		}
+	}
+
+	return "", errors.New("unable to determine bucket's region")
+}

--- a/pkg/cloudprovider/aws/object_store.go
+++ b/pkg/cloudprovider/aws/object_store.go
@@ -17,14 +17,12 @@ limitations under the License.
 package aws
 
 import (
-	"context"
 	"io"
 	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/pkg/errors"
@@ -47,30 +45,6 @@ type objectStore struct {
 
 func NewObjectStore() cloudprovider.ObjectStore {
 	return &objectStore{}
-}
-
-func getBucketRegion(bucket string) (string, error) {
-	var region string
-
-	session, err := session.NewSession()
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-
-	for _, partition := range endpoints.DefaultPartitions() {
-		for regionHint := range partition.Regions() {
-			region, _ = s3manager.GetBucketRegion(context.Background(), session, bucket, regionHint)
-
-			// we only need to try a single region hint per partition, so break after the first
-			break
-		}
-
-		if region != "" {
-			return region, nil
-		}
-	}
-
-	return "", errors.New("unable to determine bucket's region")
 }
 
 func (o *objectStore) Init(config map[string]string) error {
@@ -100,7 +74,7 @@ func (o *objectStore) Init(config map[string]string) error {
 	if s3URL == "" && region == "" {
 		var err error
 
-		region, err = getBucketRegion(bucket)
+		region, err = GetBucketRegion(bucket)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

Fixes #567 

If using restic with S3, fetch the bucket's region up-front and put it in the endpoint URL to use for restic. This makes all restic requests faster and also doesn't require any additional permission to determine the right S3 endpoint (which the default restic method does).