### PR TITLE
[WIP] when restoring a pvc, enable dynamic provisioning if no snapshot restore

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -634,6 +634,7 @@ func (s *server) runControllers(config *api.Config) error {
 		config.ResourcePriorities,
 		s.arkClient.ArkV1(),
 		s.kubeClient.CoreV1().Namespaces(),
+		s.kubeClient.CoreV1().PersistentVolumes(),
 		s.resticManager,
 		config.PodVolumeOperationTimeout.Duration,
 		s.logger,


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

Thoughts on the issue and resolution approach appreciated here.

When we attempt to restore a PV obj, it expects to find a cloud volume (either the original one, or a new one created by our snapshot restore code). If it doesn't find the volume, the PV create fails (i.e. it's not created in Kube).

So, when we go to restore a PVC for that PV, it gets created as `Lost` because the PV it's claiming does not exist.

This PR checks for the existence of the referenced PV before restoring a PVC, and if it does not exist, clears out the PV reference and relevant annotation so that a new, empty PV can be dynamically provisioned. This enables a `restic restore` to proceed properly.

There's still a separate question of what we should do when restoring a PV if the referenced cloud volume does not exist; don't think we need to address it right now but food for thought.