### PR TITLE
Add omitempty tags to optional API fields

### DIFF
--- a/pkg/apis/ark/v1/backup.go
+++ b/pkg/apis/ark/v1/backup.go
@@ -44,7 +44,7 @@ type BackupSpec struct {
 	// SnapshotVolumes specifies whether to take cloud snapshots
 	// of any PV's referenced in the set of objects included
 	// in the Backup.
-	SnapshotVolumes *bool `json:"snapshotVolumes"`
+	SnapshotVolumes *bool `json:"snapshotVolumes,omitempty"`
 
 	// TTL is a time.Duration-parseable string describing how long
 	// the Backup should be retained for.
@@ -80,7 +80,7 @@ type BackupResourceHookSpec struct {
 	// ExcludedResources specifies the resources to which this hook spec does not apply.
 	ExcludedResources []string `json:"excludedResources"`
 	// LabelSelector, if specified, filters the resources to which this hook spec applies.
-	LabelSelector *metav1.LabelSelector `json:"labelSelector"`
+	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
 	// Hooks is a list of BackupResourceHooks to execute. DEPRECATED. Replaced by PreHooks.
 	Hooks []BackupResourceHook `json:"hooks"`
 	// PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup.

--- a/pkg/apis/ark/v1/restore.go
+++ b/pkg/apis/ark/v1/restore.go
@@ -49,16 +49,16 @@ type RestoreSpec struct {
 	// LabelSelector is a metav1.LabelSelector to filter with
 	// when restoring individual objects from the backup. If empty
 	// or nil, all objects are included. Optional.
-	LabelSelector *metav1.LabelSelector `json:"labelSelector"`
+	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
 
 	// RestorePVs specifies whether to restore all included
 	// PVs from snapshot (via the cloudprovider).
-	RestorePVs *bool `json:"restorePVs"`
+	RestorePVs *bool `json:"restorePVs,omitempty"`
 
 	// IncludeClusterResources specifies whether cluster-scoped resources
 	// should be included for consideration in the restore. If null, defaults
 	// to true.
-	IncludeClusterResources *bool `json:"includeClusterResources"`
+	IncludeClusterResources *bool `json:"includeClusterResources,omitempty"`
 }
 
 // RestorePhase is a string representation of the lifecycle phase


### PR DESCRIPTION
Some API fields are optional but don't have the `omitempty` in the JSON tag. This PR adds them.