### PR TITLE
Stop restoring mirror pods

### DIFF
--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -670,6 +670,12 @@ func (ctx *context) restoreResource(resource, namespace, resourcePath string) (a
 
 		name := obj.GetName()
 
+		// TODO: move to restore item action if/when we add a ShouldRestore() method to the interface
+		if groupResource == kuberesource.Pods && obj.GetAnnotations()[v1.MirrorPodAnnotationKey] != "" {
+			ctx.infof("Not restoring pod because it's a mirror pod")
+			continue
+		}
+
 		if groupResource == kuberesource.PersistentVolumes {
 			_, found := ctx.backup.Status.VolumeBackups[name]
 			reclaimPolicy, err := collections.GetString(obj.Object, "spec.persistentVolumeReclaimPolicy")


### PR DESCRIPTION
Mirror pods are pods created from static manifest files on a node.
They're mirrored to the apiserver so they're visible when querying the
apiserver for a list of pods, but it's not possible to send a pod
containing the mirror pod annotation to the apiserver and have it be
created successfully. Instead of trying to do this, log a message that
we're skipping restoring the pod because it's a mirror pod.

Fixes #428