### PR TITLE
Fix k8s slack link in main navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ contact:
   google: https://groups.google.com/forum/#!forum/heptio-ark
   github: https://github.com/heptio/ark
   twitter: https://twitter.com/heptioark
-  slack: https://kubernetes.slack.com/messages/ark
+  slack: https://kubernetes.slack.com/messages/ark-dr
 defaults:
 - scope:
     path: master


### PR DESCRIPTION
Signed-off-by: Carlisia Pinto <carlisia@grokkingtech.io>

This fixes the slack link in the main navigation:

![image](https://user-images.githubusercontent.com/16508/42059393-1e5a23b8-7ad8-11e8-8671-65eefe7efc97.png)

Currently it points to a non existing channel `ark`, but it needs to point to `ark-dr`.