### PR TITLE
Don't restore backups or restores

### DIFF
--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -51,7 +51,19 @@ import (
 
 // nonRestorableResources is a blacklist for the restoration process. Any resources
 // included here are explicitly excluded from the restoration process.
-var nonRestorableResources = []string{"nodes", "events", "events.events.k8s.io"}
+var nonRestorableResources = []string{
+	"nodes",
+	"events",
+	"events.events.k8s.io",
+
+	// Don't ever restore backups - if appropriate, they'll be synced in from object storage.
+	// https://github.com/heptio/ark/issues/622
+	"backups.ark.heptio.com",
+
+	// Restores are cluster-specific, and don't have value moving across clusters.
+	// https://github.com/heptio/ark/issues/622
+	"restores.ark.heptio.com",
+}
 
 type restoreController struct {
 	namespace           string

--- a/pkg/controller/restore_controller_test.go
+++ b/pkg/controller/restore_controller_test.go
@@ -255,6 +255,28 @@ func TestProcessRestore(t *testing.T) {
 				"Invalid included/excluded resource lists: excludes list cannot contain an item in the includes list: events.events.k8s.io",
 			},
 		},
+		{
+			name:          "restoration of backups.ark.heptio.com is not supported",
+			restore:       NewRestore("foo", "bar", "backup-1", "ns-1", "backups.ark.heptio.com", api.RestorePhaseNew).Restore,
+			backup:        arktest.NewTestBackup().WithName("backup-1").Backup,
+			expectedErr:   false,
+			expectedPhase: string(api.RestorePhaseFailedValidation),
+			expectedValidationErrors: []string{
+				"backups.ark.heptio.com are non-restorable resources",
+				"Invalid included/excluded resource lists: excludes list cannot contain an item in the includes list: backups.ark.heptio.com",
+			},
+		},
+		{
+			name:          "restoration of restores.ark.heptio.com is not supported",
+			restore:       NewRestore("foo", "bar", "backup-1", "ns-1", "restores.ark.heptio.com", api.RestorePhaseNew).Restore,
+			backup:        arktest.NewTestBackup().WithName("backup-1").Backup,
+			expectedErr:   false,
+			expectedPhase: string(api.RestorePhaseFailedValidation),
+			expectedValidationErrors: []string{
+				"restores.ark.heptio.com are non-restorable resources",
+				"Invalid included/excluded resource lists: excludes list cannot contain an item in the includes list: restores.ark.heptio.com",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Add backups and restores the list of non restorable resources. Backups,
if applicable, are synced from object storage by the backup sync
controller. Restores are specific to a cluster and don't have value
moving across clusters.

Signed-off-by: Andy Goldstein <andy.goldstein@gmail.com>

Fixes #622