### PR TITLE
set --hostname flag for restic backups

### DIFF
--- a/pkg/restic/command_factory.go
+++ b/pkg/restic/command_factory.go
@@ -23,13 +23,18 @@ import (
 
 // BackupCommand returns a Command for running a restic backup.
 func BackupCommand(repoIdentifier, passwordFile, path string, tags map[string]string) *Command {
+	// --hostname flag is provided with a generic value because restic uses the hostname
+	// to find a parent snapshot, and by default it will be the name of the daemonset pod
+	// where the `restic backup` command is run. If this pod is recreated, we want to continue
+	// taking incremental backups rather than triggering a full one due to a new pod name.
+
 	return &Command{
 		Command:        "backup",
 		RepoIdentifier: repoIdentifier,
 		PasswordFile:   passwordFile,
 		Dir:            path,
 		Args:           []string{"."},
-		ExtraFlags:     backupTagFlags(tags),
+		ExtraFlags:     append(backupTagFlags(tags), "--hostname=ark"),
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

Addresses part of #635 

Have tested on an AWS cluster by taking a backup, deleting the daemonset pods, taking a new backup, and manually verifying that the new restic backups have the parent snapshot ID set.