### PR TITLE
cherry-pick commits for v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+#### [v0.9.1](https://github.com/heptio/ark/releases/tag/v0.9.1) - 2018-07-23
+
+##### Bug Fixes:
+  * Require namespace for Ark's CRDs to already exist at server startup (#676, @skriss)
+  * Require all Ark CRDs to exist at server startup (#683, @skriss)
+  * Fix `latest` tagging in Makefile (#690, @skriss)
+  * Make Ark compatible with clusters that don't have the `rbac.authorization.k8s.io/v1` API group (#682, @nrb)
+  * Don't consider missing snapshots an error during backup deletion, limit backup deletion requests per backup to 1 (#687, @skriss)
+
 #### [v0.9.0](https://github.com/heptio/ark/releases/tag/v0.9.0) - 2018-07-06
 
 ##### Highlights:

--- a/Makefile
+++ b/Makefile
@@ -138,10 +138,10 @@ all-push:
 push: .push-$(DOTFILE_IMAGE) push-name
 .push-$(DOTFILE_IMAGE): .container-$(DOTFILE_IMAGE)
 	@docker push $(IMAGE):$(VERSION)
-	@if [[ "$(TAG_LATEST)" == "true" ]]; then \
-		docker tag $(IMAGE):$(VERSION) $(IMAGE):latest; \
-		docker push $(IMAGE):latest; \
-	fi
+ifeq ($(TAG_LATEST), true)
+	docker tag $(IMAGE):$(VERSION) $(IMAGE):latest
+	docker push $(IMAGE):latest
+endif
 	@docker images -q $(IMAGE):$(VERSION) > $@
 
 push-name:

--- a/pkg/apis/ark/v1/register.go
+++ b/pkg/apis/ark/v1/register.go
@@ -41,27 +41,41 @@ func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
 }
 
+type typeInfo struct {
+	PluralName   string
+	ItemType     runtime.Object
+	ItemListType runtime.Object
+}
+
+func newTypeInfo(pluralName string, itemType, itemListType runtime.Object) typeInfo {
+	return typeInfo{
+		PluralName:   pluralName,
+		ItemType:     itemType,
+		ItemListType: itemListType,
+	}
+}
+
+// CustomResources returns a map of all custom resources within the Ark
+// API group, keyed on Kind.
+func CustomResources() map[string]typeInfo {
+	return map[string]typeInfo{
+		"Backup":              newTypeInfo("backups", &Backup{}, &BackupList{}),
+		"Restore":             newTypeInfo("restores", &Restore{}, &RestoreList{}),
+		"Schedule":            newTypeInfo("schedules", &Schedule{}, &ScheduleList{}),
+		"Config":              newTypeInfo("configs", &Config{}, &ConfigList{}),
+		"DownloadRequest":     newTypeInfo("downloadrequests", &DownloadRequest{}, &DownloadRequestList{}),
+		"DeleteBackupRequest": newTypeInfo("deletebackuprequests", &DeleteBackupRequest{}, &DeleteBackupRequestList{}),
+		"PodVolumeBackup":     newTypeInfo("podvolumebackups", &PodVolumeBackup{}, &PodVolumeBackupList{}),
+		"PodVolumeRestore":    newTypeInfo("podvolumerestores", &PodVolumeRestore{}, &PodVolumeRestoreList{}),
+		"ResticRepository":    newTypeInfo("resticrepositories", &ResticRepository{}, &ResticRepositoryList{}),
+	}
+}
+
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
-		&Backup{},
-		&BackupList{},
-		&Schedule{},
-		&ScheduleList{},
-		&Restore{},
-		&RestoreList{},
-		&Config{},
-		&ConfigList{},
-		&DownloadRequest{},
-		&DownloadRequestList{},
-		&DeleteBackupRequest{},
-		&DeleteBackupRequestList{},
-		&PodVolumeBackup{},
-		&PodVolumeBackupList{},
-		&PodVolumeRestore{},
-		&PodVolumeRestoreList{},
-		&ResticRepository{},
-		&ResticRepositoryList{},
-	)
+	for _, typeInfo := range CustomResources() {
+		scheme.AddKnownTypes(SchemeGroupVersion, typeInfo.ItemType, typeInfo.ItemListType)
+	}
+
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
 }

--- a/pkg/backup/rbac.go
+++ b/pkg/backup/rbac.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2018 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	"github.com/pkg/errors"
+	rbac "k8s.io/api/rbac/v1"
+	rbacbeta "k8s.io/api/rbac/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	rbacclient "k8s.io/client-go/kubernetes/typed/rbac/v1"
+	rbacbetaclient "k8s.io/client-go/kubernetes/typed/rbac/v1beta1"
+)
+
+// ClusterRoleBindingLister allows for listing ClusterRoleBindings in a version-independent way.
+type ClusterRoleBindingLister interface {
+	// List returns a slice of ClusterRoleBindings which can represent either v1 or v1beta1 ClusterRoleBindings.
+	List() ([]ClusterRoleBinding, error)
+}
+
+// noopClusterRoleBindingLister exists to handle clusters where RBAC is disabled.
+type noopClusterRoleBindingLister struct {
+}
+
+func (noop noopClusterRoleBindingLister) List() ([]ClusterRoleBinding, error) {
+	return []ClusterRoleBinding{}, nil
+}
+
+type v1ClusterRoleBindingLister struct {
+	client rbacclient.ClusterRoleBindingInterface
+}
+
+func (v1 v1ClusterRoleBindingLister) List() ([]ClusterRoleBinding, error) {
+	crbList, err := v1.client.List(metav1.ListOptions{})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	var crbs []ClusterRoleBinding
+	for _, crb := range crbList.Items {
+		crbs = append(crbs, v1ClusterRoleBinding{crb: crb})
+	}
+
+	return crbs, nil
+}
+
+type v1beta1ClusterRoleBindingLister struct {
+	client rbacbetaclient.ClusterRoleBindingInterface
+}
+
+func (v1beta1 v1beta1ClusterRoleBindingLister) List() ([]ClusterRoleBinding, error) {
+	crbList, err := v1beta1.client.List(metav1.ListOptions{})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	var crbs []ClusterRoleBinding
+	for _, crb := range crbList.Items {
+		crbs = append(crbs, v1beta1ClusterRoleBinding{crb: crb})
+	}
+
+	return crbs, nil
+}
+
+// NewClusterRoleBindingListerMap creates a map of RBAC version strings to their associated
+// ClusterRoleBindingLister structs.
+// Necessary so that callers to the ClusterRoleBindingLister interfaces don't need the kubernetes.Interface.
+func NewClusterRoleBindingListerMap(clientset kubernetes.Interface) map[string]ClusterRoleBindingLister {
+	return map[string]ClusterRoleBindingLister{
+		rbac.SchemeGroupVersion.Version:     v1ClusterRoleBindingLister{client: clientset.RbacV1().ClusterRoleBindings()},
+		rbacbeta.SchemeGroupVersion.Version: v1beta1ClusterRoleBindingLister{client: clientset.RbacV1beta1().ClusterRoleBindings()},
+		"": noopClusterRoleBindingLister{},
+	}
+}
+
+// ClusterRoleBinding abstracts access to ClusterRoleBindings whether they're v1 or v1beta1.
+type ClusterRoleBinding interface {
+	// Name returns the name of a ClusterRoleBinding.
+	Name() string
+	// ServiceAccountSubjects returns the names of subjects that are service accounts in the given namespace.
+	ServiceAccountSubjects(namespace string) []string
+	// RoleRefName returns the name of a ClusterRoleBinding's RoleRef.
+	RoleRefName() string
+}
+
+type v1ClusterRoleBinding struct {
+	crb rbac.ClusterRoleBinding
+}
+
+func (c v1ClusterRoleBinding) Name() string {
+	return c.crb.Name
+}
+
+func (c v1ClusterRoleBinding) RoleRefName() string {
+	return c.crb.RoleRef.Name
+}
+
+func (c v1ClusterRoleBinding) ServiceAccountSubjects(namespace string) []string {
+	var saSubjects []string
+	for _, s := range c.crb.Subjects {
+		if s.Kind == rbac.ServiceAccountKind && s.Namespace == namespace {
+			saSubjects = append(saSubjects, s.Name)
+		}
+	}
+	return saSubjects
+}
+
+type v1beta1ClusterRoleBinding struct {
+	crb rbacbeta.ClusterRoleBinding
+}
+
+func (c v1beta1ClusterRoleBinding) Name() string {
+	return c.crb.Name
+}
+
+func (c v1beta1ClusterRoleBinding) RoleRefName() string {
+	return c.crb.RoleRef.Name
+}
+
+func (c v1beta1ClusterRoleBinding) ServiceAccountSubjects(namespace string) []string {
+	var saSubjects []string
+	for _, s := range c.crb.Subjects {
+		if s.Kind == rbac.ServiceAccountKind && s.Namespace == namespace {
+			saSubjects = append(saSubjects, s.Name)
+		}
+	}
+	return saSubjects
+}

--- a/pkg/backup/service_account_action.go
+++ b/pkg/backup/service_account_action.go
@@ -93,7 +93,7 @@ func (a *serviceAccountAction) Execute(item runtime.Unstructured, backup *v1.Bac
 		for _, s := range crb.ServiceAccountSubjects(namespace) {
 			if s == name {
 				a.log.Infof("Adding clusterrole %s and clusterrolebinding %s to additionalItems since serviceaccount %s/%s is a subject",
-					crb.RoleRefName(), crb, namespace, name)
+					crb.RoleRefName(), crb.Name(), namespace, name)
 
 				bindings.Insert(crb.Name())
 				roles.Insert(crb.RoleRefName())

--- a/pkg/backup/service_account_action.go
+++ b/pkg/backup/service_account_action.go
@@ -25,28 +25,41 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	rbacclient "k8s.io/client-go/kubernetes/typed/rbac/v1"
 
 	"github.com/heptio/ark/pkg/apis/ark/v1"
+	arkdiscovery "github.com/heptio/ark/pkg/discovery"
 	"github.com/heptio/ark/pkg/kuberesource"
 )
 
 // serviceAccountAction implements ItemAction.
 type serviceAccountAction struct {
 	log                 logrus.FieldLogger
-	clusterRoleBindings []rbac.ClusterRoleBinding
+	clusterRoleBindings []ClusterRoleBinding
 }
 
 // NewServiceAccountAction creates a new ItemAction for service accounts.
-func NewServiceAccountAction(log logrus.FieldLogger, client rbacclient.ClusterRoleBindingInterface) (ItemAction, error) {
-	clusterRoleBindings, err := client.List(metav1.ListOptions{})
+func NewServiceAccountAction(log logrus.FieldLogger, clusterRoleBindingListers map[string]ClusterRoleBindingLister, discoveryHelper arkdiscovery.Helper) (ItemAction, error) {
+	// Look up the supported RBAC version
+	var supportedAPI metav1.GroupVersionForDiscovery
+	for _, ag := range discoveryHelper.APIGroups() {
+		if ag.Name == rbac.GroupName {
+			supportedAPI = ag.PreferredVersion
+			break
+		}
+	}
+
+	crbLister := clusterRoleBindingListers[supportedAPI.Version]
+
+	// This should be safe because the List call will return a 0-item slice
+	// if there's no matching API version.
+	crbs, err := crbLister.List()
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	return &serviceAccountAction{
 		log:                 log,
-		clusterRoleBindings: clusterRoleBindings.Items,
+		clusterRoleBindings: crbs,
 	}, nil
 }
 
@@ -76,14 +89,14 @@ func (a *serviceAccountAction) Execute(item runtime.Unstructured, backup *v1.Bac
 		roles     = sets.NewString()
 	)
 
-	for _, clusterRoleBinding := range a.clusterRoleBindings {
-		for _, subj := range clusterRoleBinding.Subjects {
-			if subj.Kind == rbac.ServiceAccountKind && subj.Namespace == namespace && subj.Name == name {
+	for _, crb := range a.clusterRoleBindings {
+		for _, s := range crb.ServiceAccountSubjects(namespace) {
+			if s == name {
 				a.log.Infof("Adding clusterrole %s and clusterrolebinding %s to additionalItems since serviceaccount %s/%s is a subject",
-					clusterRoleBinding.RoleRef.Name, clusterRoleBinding.Name, namespace, name)
+					crb.RoleRefName(), crb, namespace, name)
 
-				bindings.Insert(clusterRoleBinding.Name)
-				roles.Insert(clusterRoleBinding.RoleRef.Name)
+				bindings.Insert(crb.Name())
+				roles.Insert(crb.RoleRefName())
 				break
 			}
 		}

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -28,6 +28,7 @@ import (
 	"github.com/heptio/ark/pkg/cloudprovider/azure"
 	"github.com/heptio/ark/pkg/cloudprovider/gcp"
 	"github.com/heptio/ark/pkg/cmd"
+	arkdiscovery "github.com/heptio/ark/pkg/discovery"
 	arkplugin "github.com/heptio/ark/pkg/plugin"
 	"github.com/heptio/ark/pkg/restore"
 )
@@ -87,7 +88,13 @@ func NewCommand(f client.Factory) *cobra.Command {
 					clientset, err := f.KubeClient()
 					cmd.CheckError(err)
 
-					action, err = backup.NewServiceAccountAction(logger, clientset.RbacV1().ClusterRoleBindings())
+					discoveryHelper, err := arkdiscovery.NewHelper(clientset.Discovery(), logger)
+					cmd.CheckError(err)
+
+					action, err = backup.NewServiceAccountAction(
+						logger,
+						backup.NewClusterRoleBindingListerMap(clientset),
+						discoveryHelper)
 					cmd.CheckError(err)
 				default:
 					logger.Fatal("Unrecognized plugin name")

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -661,6 +661,7 @@ func (s *server) runControllers(config *api.Config) error {
 		gcController := controller.NewGCController(
 			s.logger,
 			s.sharedInformerFactory.Ark().V1().Backups(),
+			s.sharedInformerFactory.Ark().V1().DeleteBackupRequests(),
 			s.arkClient.ArkV1(),
 			config.GCSyncPeriod.Duration,
 		)

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -38,6 +38,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	kubeerrs "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
@@ -151,6 +153,7 @@ type server struct {
 	snapshotService       cloudprovider.SnapshotService
 	discoveryClient       discovery.DiscoveryInterface
 	clientPool            dynamic.ClientPool
+	discoveryHelper       arkdiscovery.Helper
 	sharedInformerFactory informers.SharedInformerFactory
 	ctx                   context.Context
 	cancelFunc            context.CancelFunc
@@ -213,6 +216,15 @@ func (s *server) run() error {
 		return err
 	}
 
+	if err := s.initDiscoveryHelper(); err != nil {
+		return err
+	}
+
+	// check to ensure all Ark CRDs exist
+	if err := s.arkResourcesExist(); err != nil {
+		return err
+	}
+
 	originalConfig, err := s.loadConfig()
 	if err != nil {
 		return err
@@ -256,6 +268,68 @@ func (s *server) namespaceExists(namespace string) error {
 	}
 
 	s.logger.WithField("namespace", namespace).Info("Namespace exists")
+	return nil
+}
+
+// initDiscoveryHelper instantiates the server's discovery helper and spawns a
+// goroutine to call Refresh() every 5 minutes.
+func (s *server) initDiscoveryHelper() error {
+	discoveryHelper, err := arkdiscovery.NewHelper(s.discoveryClient, s.logger)
+	if err != nil {
+		return err
+	}
+	s.discoveryHelper = discoveryHelper
+
+	go wait.Until(
+		func() {
+			if err := discoveryHelper.Refresh(); err != nil {
+				s.logger.WithError(err).Error("Error refreshing discovery")
+			}
+		},
+		5*time.Minute,
+		s.ctx.Done(),
+	)
+
+	return nil
+}
+
+// arkResourcesExist checks for the existence of each Ark CRD via discovery
+// and returns an error if any of them don't exist.
+func (s *server) arkResourcesExist() error {
+	s.logger.Info("Checking existence of Ark custom resource definitions")
+
+	var arkGroupVersion *metav1.APIResourceList
+	for _, gv := range s.discoveryHelper.Resources() {
+		if gv.GroupVersion == api.SchemeGroupVersion.String() {
+			arkGroupVersion = gv
+			break
+		}
+	}
+
+	if arkGroupVersion == nil {
+		return errors.Errorf("Ark API group %s not found", api.SchemeGroupVersion)
+	}
+
+	foundResources := sets.NewString()
+	for _, resource := range arkGroupVersion.APIResources {
+		foundResources.Insert(resource.Kind)
+	}
+
+	var errs []error
+	for kind := range api.CustomResources() {
+		if foundResources.Has(kind) {
+			s.logger.WithField("kind", kind).Debug("Found custom resource")
+			continue
+		}
+
+		errs = append(errs, errors.Errorf("custom resource %s not found in Ark API group %s", kind, api.SchemeGroupVersion))
+	}
+
+	if len(errs) > 0 {
+		return kubeerrs.NewAggregate(errs)
+	}
+
+	s.logger.Info("All Ark custom resource definitions exist")
 	return nil
 }
 
@@ -537,27 +611,13 @@ func (s *server) runControllers(config *api.Config) error {
 		wg.Done()
 	}()
 
-	discoveryHelper, err := arkdiscovery.NewHelper(s.discoveryClient, s.logger)
-	if err != nil {
-		return err
-	}
-	go wait.Until(
-		func() {
-			if err := discoveryHelper.Refresh(); err != nil {
-				s.logger.WithError(err).Error("Error refreshing discovery")
-			}
-		},
-		5*time.Minute,
-		ctx.Done(),
-	)
-
 	if config.RestoreOnlyMode {
 		s.logger.Info("Restore only mode - not starting the backup, schedule, delete-backup, or GC controllers")
 	} else {
 		backupTracker := controller.NewBackupTracker()
 
 		backupper, err := backup.NewKubernetesBackupper(
-			discoveryHelper,
+			s.discoveryHelper,
 			client.NewDynamicFactory(s.clientPool),
 			podexec.NewPodCommandExecutor(s.kubeClientConfig, s.kubeClient.CoreV1().RESTClient()),
 			s.snapshotService,
@@ -633,7 +693,7 @@ func (s *server) runControllers(config *api.Config) error {
 	}
 
 	restorer, err := restore.NewKubernetesRestorer(
-		discoveryHelper,
+		s.discoveryHelper,
 		client.NewDynamicFactory(s.clientPool),
 		s.backupService,
 		s.snapshotService,

--- a/pkg/install/crd.go
+++ b/pkg/install/crd.go
@@ -27,17 +27,13 @@ import (
 
 // CRDs returns a list of the CRD types for all of the required Ark CRDs
 func CRDs() []*apiextv1beta1.CustomResourceDefinition {
-	return []*apiextv1beta1.CustomResourceDefinition{
-		crd("Backup", "backups"),
-		crd("Schedule", "schedules"),
-		crd("Restore", "restores"),
-		crd("Config", "configs"),
-		crd("DownloadRequest", "downloadrequests"),
-		crd("DeleteBackupRequest", "deletebackuprequests"),
-		crd("PodVolumeBackup", "podvolumebackups"),
-		crd("PodVolumeRestore", "podvolumerestores"),
-		crd("ResticRepository", "resticrepositories"),
+	var crds []*apiextv1beta1.CustomResourceDefinition
+
+	for kind, typeInfo := range arkv1.CustomResources() {
+		crds = append(crds, crd(kind, typeInfo.PluralName))
 	}
+
+	return crds
 }
 
 func crd(kind, plural string) *apiextv1beta1.CustomResourceDefinition {

--- a/pkg/util/test/fake_discovery_helper.go
+++ b/pkg/util/test/fake_discovery_helper.go
@@ -29,6 +29,7 @@ type FakeDiscoveryHelper struct {
 	ResourceList       []*metav1.APIResourceList
 	Mapper             meta.RESTMapper
 	AutoReturnResource bool
+	APIGroupsList      []metav1.APIGroup
 }
 
 func NewFakeDiscoveryHelper(autoReturnResource bool, resources map[schema.GroupVersionResource]schema.GroupVersionResource) *FakeDiscoveryHelper {
@@ -54,6 +55,14 @@ func NewFakeDiscoveryHelper(autoReturnResource bool, resources map[schema.GroupV
 		}
 
 		apiResourceMap[gvString] = append(apiResourceMap[gvString], metav1.APIResource{Name: gvr.Resource})
+		helper.APIGroupsList = append(helper.APIGroupsList,
+			metav1.APIGroup{
+				Name: gvr.Group,
+				PreferredVersion: metav1.GroupVersionForDiscovery{
+					GroupVersion: gvString,
+					Version:      gvr.Version,
+				},
+			})
 	}
 
 	for group, resources := range apiResourceMap {
@@ -109,4 +118,8 @@ func (dh *FakeDiscoveryHelper) ResourceFor(input schema.GroupVersionResource) (s
 	}
 
 	return schema.GroupVersionResource{}, metav1.APIResource{}, errors.New("APIResource not found")
+}
+
+func (dh *FakeDiscoveryHelper) APIGroups() []metav1.APIGroup {
+	return dh.APIGroupsList
 }


### PR DESCRIPTION
##### Bug Fixes:
  * Require namespace for Ark's CRDs to already exist at server startup (#676, @skriss)
  * Require all Ark CRDs to exist at server startup (#683, @skriss)
  * Fix `latest` tagging in Makefile (#690, @skriss)
  * Make Ark compatible with clusters that don't have the `rbac.authorization.k8s.io/v1` API group (#682, @nrb)
  * Don't consider missing snapshots an error during backup deletion, limit backup deletion requests per backup to 1 (#687, @skriss)