### PR TITLE
[WIP] prototype of new storage interface

### DIFF
--- a/pkg/cloudprovider/block_store.go
+++ b/pkg/cloudprovider/block_store.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2017 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudprovider
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// BlockStore exposes basic block-storage operations required
+// by Ark.
+type BlockStore interface {
+	// Init prepares the BlockStore for usage using the provided map of
+	// configuration key-value pairs. It returns an error if the BlockStore
+	// cannot be initialized from the provided config.
+	Init(config map[string]string) error
+
+	// CreateVolumeFromSnapshot creates a new block volume in the specified
+	// availability zone, initialized from the provided snapshot,
+	// and with the specified type and IOPS (if using provisioned IOPS).
+	CreateVolumeFromSnapshot(snapshotID, volumeType, volumeAZ string, iops *int64) (volumeID string, err error)
+
+	// GetVolumeID returns the cloud provider specific identifier for the PersistentVolume.
+	GetVolumeID(pv runtime.Unstructured) (string, error)
+
+	// SetVolumeID sets the cloud provider specific identifier for the PersistentVolume.
+	SetVolumeID(pv runtime.Unstructured, volumeID string) (runtime.Unstructured, error)
+
+	// GetVolumeInfo returns the type and IOPS (if using provisioned IOPS) for
+	// the specified block volume in the given availability zone.
+	GetVolumeInfo(volumeID, volumeAZ string) (string, *int64, error)
+
+	// CreateSnapshot creates a snapshot of the specified block volume, and applies the provided
+	// set of tags to the snapshot.
+	CreateSnapshot(volumeID, volumeAZ string, tags map[string]string) (snapshotID string, err error)
+
+	// DeleteSnapshot deletes the specified volume snapshot.
+	DeleteSnapshot(snapshotID string) error
+}

--- a/pkg/cloudprovider/object_store.go
+++ b/pkg/cloudprovider/object_store.go
@@ -19,8 +19,6 @@ package cloudprovider
 import (
 	"io"
 	"time"
-
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // ObjectStore exposes basic object-storage operations required
@@ -55,35 +53,4 @@ type ObjectStore interface {
 
 	// CreateSignedURL creates a pre-signed URL for the given bucket and key that expires after ttl.
 	CreateSignedURL(bucket, key string, ttl time.Duration) (string, error)
-}
-
-// BlockStore exposes basic block-storage operations required
-// by Ark.
-type BlockStore interface {
-	// Init prepares the BlockStore for usage using the provided map of
-	// configuration key-value pairs. It returns an error if the BlockStore
-	// cannot be initialized from the provided config.
-	Init(config map[string]string) error
-
-	// CreateVolumeFromSnapshot creates a new block volume in the specified
-	// availability zone, initialized from the provided snapshot,
-	// and with the specified type and IOPS (if using provisioned IOPS).
-	CreateVolumeFromSnapshot(snapshotID, volumeType, volumeAZ string, iops *int64) (volumeID string, err error)
-
-	// GetVolumeID returns the cloud provider specific identifier for the PersistentVolume.
-	GetVolumeID(pv runtime.Unstructured) (string, error)
-
-	// SetVolumeID sets the cloud provider specific identifier for the PersistentVolume.
-	SetVolumeID(pv runtime.Unstructured, volumeID string) (runtime.Unstructured, error)
-
-	// GetVolumeInfo returns the type and IOPS (if using provisioned IOPS) for
-	// the specified block volume in the given availability zone.
-	GetVolumeInfo(volumeID, volumeAZ string) (string, *int64, error)
-
-	// CreateSnapshot creates a snapshot of the specified block volume, and applies the provided
-	// set of tags to the snapshot.
-	CreateSnapshot(volumeID, volumeAZ string, tags map[string]string) (snapshotID string, err error)
-
-	// DeleteSnapshot deletes the specified volume snapshot.
-	DeleteSnapshot(snapshotID string) error
 }

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -64,6 +64,7 @@ import (
 	"github.com/heptio/ark/pkg/podexec"
 	"github.com/heptio/ark/pkg/restic"
 	"github.com/heptio/ark/pkg/restore"
+	"github.com/heptio/ark/pkg/storage"
 	"github.com/heptio/ark/pkg/util/kube"
 	"github.com/heptio/ark/pkg/util/logging"
 	"github.com/heptio/ark/pkg/util/stringslice"
@@ -579,8 +580,8 @@ func (s *server) runControllers(config *api.Config) error {
 	cloudBackupCacheResyncPeriod := durationMin(config.GCSyncPeriod.Duration, config.BackupSyncPeriod.Duration)
 	s.logger.Infof("Caching cloud backups every %s", cloudBackupCacheResyncPeriod)
 
-	liveBackupLister := cloudprovider.NewLiveBackupLister(s.logger, s.objectStore)
-	cachedBackupLister := cloudprovider.NewBackupCache(ctx, liveBackupLister, cloudBackupCacheResyncPeriod, s.logger)
+	liveBackupLister := storage.NewLiveBackupLister(s.logger, s.objectStore)
+	cachedBackupLister := storage.NewBackupCache(ctx, liveBackupLister, cloudBackupCacheResyncPeriod, s.logger)
 
 	go func() {
 		metricsMux := http.NewServeMux()

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -48,6 +48,7 @@ import (
 	listers "github.com/heptio/ark/pkg/generated/listers/ark/v1"
 	"github.com/heptio/ark/pkg/metrics"
 	"github.com/heptio/ark/pkg/plugin"
+	"github.com/heptio/ark/pkg/storage"
 	"github.com/heptio/ark/pkg/util/collections"
 	"github.com/heptio/ark/pkg/util/encode"
 	kubeutil "github.com/heptio/ark/pkg/util/kube"
@@ -424,7 +425,7 @@ func (controller *backupController) runBackup(backup *api.Backup, bucket string)
 		controller.logger.WithError(err).Error("error closing gzippedLogFile")
 	}
 
-	if err := cloudprovider.UploadBackup(log, objectStore, bucket, backup.Name, backupJSONToUpload, backupFileToUpload, logFile); err != nil {
+	if err := storage.UploadBackup(log, objectStore, bucket, backup.Name, backupJSONToUpload, backupFileToUpload, logFile); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/pkg/controller/backup_deletion_controller.go
+++ b/pkg/controller/backup_deletion_controller.go
@@ -29,6 +29,7 @@ import (
 	informers "github.com/heptio/ark/pkg/generated/informers/externalversions/ark/v1"
 	listers "github.com/heptio/ark/pkg/generated/listers/ark/v1"
 	"github.com/heptio/ark/pkg/restic"
+	"github.com/heptio/ark/pkg/storage"
 	"github.com/heptio/ark/pkg/util/kube"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -58,7 +59,7 @@ type backupDeletionController struct {
 	resticMgr                 restic.RepositoryManager
 	podvolumeBackupLister     listers.PodVolumeBackupLister
 
-	deleteBackupDir    cloudprovider.DeleteBackupDirFunc
+	deleteBackupDir    storage.DeleteBackupDirFunc
 	processRequestFunc func(*v1.DeleteBackupRequest) error
 	clock              clock.Clock
 }
@@ -92,7 +93,7 @@ func NewBackupDeletionController(
 		resticMgr:                 resticMgr,
 
 		podvolumeBackupLister: podvolumeBackupInformer.Lister(),
-		deleteBackupDir:       cloudprovider.DeleteBackupDir,
+		deleteBackupDir:       storage.DeleteBackupDir,
 		clock:                 &clock.RealClock{},
 	}
 

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -31,17 +31,17 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	api "github.com/heptio/ark/pkg/apis/ark/v1"
-	"github.com/heptio/ark/pkg/cloudprovider"
 	arkv1client "github.com/heptio/ark/pkg/generated/clientset/versioned/typed/ark/v1"
 	informers "github.com/heptio/ark/pkg/generated/informers/externalversions/ark/v1"
 	listers "github.com/heptio/ark/pkg/generated/listers/ark/v1"
+	"github.com/heptio/ark/pkg/storage"
 	"github.com/heptio/ark/pkg/util/kube"
 	"github.com/heptio/ark/pkg/util/stringslice"
 )
 
 type backupSyncController struct {
 	client               arkv1client.BackupsGetter
-	cloudBackupLister    cloudprovider.BackupLister
+	cloudBackupLister    storage.BackupLister
 	bucket               string
 	syncPeriod           time.Duration
 	namespace            string
@@ -52,7 +52,7 @@ type backupSyncController struct {
 
 func NewBackupSyncController(
 	client arkv1client.BackupsGetter,
-	cloudBackupLister cloudprovider.BackupLister,
+	cloudBackupLister storage.BackupLister,
 	bucket string,
 	syncPeriod time.Duration,
 	namespace string,

--- a/pkg/controller/download_request_controller.go
+++ b/pkg/controller/download_request_controller.go
@@ -40,6 +40,7 @@ import (
 	arkv1client "github.com/heptio/ark/pkg/generated/clientset/versioned/typed/ark/v1"
 	informers "github.com/heptio/ark/pkg/generated/informers/externalversions/ark/v1"
 	listers "github.com/heptio/ark/pkg/generated/listers/ark/v1"
+	"github.com/heptio/ark/pkg/storage"
 	"github.com/heptio/ark/pkg/util/kube"
 )
 
@@ -56,7 +57,7 @@ type downloadRequestController struct {
 	clock                       clock.Clock
 	logger                      logrus.FieldLogger
 
-	createSignedURL cloudprovider.CreateSignedURLFunc
+	createSignedURL storage.CreateSignedURLFunc
 }
 
 // NewDownloadRequestController creates a new DownloadRequestController.
@@ -80,7 +81,7 @@ func NewDownloadRequestController(
 		clock:                       &clock.RealClock{},
 		logger:                      logger,
 
-		createSignedURL: cloudprovider.CreateSignedURL,
+		createSignedURL: storage.CreateSignedURL,
 	}
 
 	c.syncHandler = c.processDownloadRequest

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -48,6 +48,7 @@ import (
 	"github.com/heptio/ark/pkg/metrics"
 	"github.com/heptio/ark/pkg/plugin"
 	"github.com/heptio/ark/pkg/restore"
+	"github.com/heptio/ark/pkg/storage"
 	"github.com/heptio/ark/pkg/util/boolptr"
 	"github.com/heptio/ark/pkg/util/collections"
 	kubeutil "github.com/heptio/ark/pkg/util/kube"
@@ -89,10 +90,10 @@ type restoreController struct {
 	pluginRegistry      plugin.Registry
 	metrics             *metrics.ServerMetrics
 
-	getBackup            cloudprovider.GetBackupFunc
-	downloadBackup       cloudprovider.DownloadBackupFunc
-	uploadRestoreLog     cloudprovider.UploadRestoreLogFunc
-	uploadRestoreResults cloudprovider.UploadRestoreResultsFunc
+	getBackup            storage.GetBackupFunc
+	downloadBackup       storage.DownloadBackupFunc
+	uploadRestoreLog     storage.UploadRestoreLogFunc
+	uploadRestoreResults storage.UploadRestoreResultsFunc
 	newPluginManager     func(logger logrus.FieldLogger, logLevel logrus.Level, pluginRegistry plugin.Registry) plugin.Manager
 }
 
@@ -130,10 +131,10 @@ func NewRestoreController(
 		pluginRegistry:      pluginRegistry,
 		metrics:             metrics,
 
-		getBackup:            cloudprovider.GetBackup,
-		downloadBackup:       cloudprovider.DownloadBackup,
-		uploadRestoreLog:     cloudprovider.UploadRestoreLog,
-		uploadRestoreResults: cloudprovider.UploadRestoreResults,
+		getBackup:            storage.GetBackup,
+		downloadBackup:       storage.DownloadBackup,
+		uploadRestoreLog:     storage.UploadRestoreLog,
+		uploadRestoreResults: storage.UploadRestoreResults,
 		newPluginManager: func(logger logrus.FieldLogger, logLevel logrus.Level, pluginRegistry plugin.Registry) plugin.Manager {
 			return plugin.NewManager(logger, logLevel, pluginRegistry)
 		},
@@ -602,7 +603,7 @@ func (c *restoreController) runRestore(
 func downloadToTempFile(
 	objectStore cloudprovider.ObjectStore,
 	bucket, backupName string,
-	downloadBackup cloudprovider.DownloadBackupFunc,
+	downloadBackup storage.DownloadBackupFunc,
 	logger logrus.FieldLogger,
 ) (*os.File, error) {
 	readCloser, err := downloadBackup(objectStore, bucket, backupName)

--- a/pkg/storage/accessor.go
+++ b/pkg/storage/accessor.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"io"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	arkv1api "github.com/heptio/ark/pkg/apis/ark/v1"
+	"github.com/heptio/ark/pkg/plugin"
+)
+
+type Accessor interface {
+	SaveBackupLog(log io.Reader) error
+
+	SaveBackupMetadata(metadata io.Reader) error
+
+	DeleteBackupMetadata() error
+
+	SaveBackupData(backup io.Reader) error
+
+	SaveBackup(metadata, backup, log io.Reader) error
+
+	GetBackupData() (io.ReadCloser, error)
+
+	GetBackupMetadata() (*arkv1api.Backup, error)
+
+	DeleteBackup() error
+
+	SaveRestoreLog(restore string, log io.Reader) error
+
+	SaveRestoreResults(restore string, results io.Reader) error
+}
+
+func BackupAccessor(backup string, location *arkv1api.BackupStorageLocation, pluginManager plugin.Manager, log logrus.FieldLogger) (Accessor, error) {
+	switch {
+	case location.Spec.ObjectStorage != nil:
+		if location.Spec.Provider == "" {
+			return nil, errors.New("object storage provider name must not be empty")
+		}
+
+		objectStore, err := pluginManager.GetObjectStore(location.Spec.Provider)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := objectStore.Init(location.Spec.Config); err != nil {
+			return nil, err
+		}
+
+		return &objectStoreBackupAccessor{
+			objectStore: objectStore,
+			bucket:      location.Spec.ObjectStorage.Bucket,
+			prefix:      location.Spec.ObjectStorage.Prefix,
+			backup:      backup,
+			log:         log,
+		}, nil
+	}
+
+	return nil, errors.New("no backup storage location backend configured")
+}

--- a/pkg/storage/backup_cache.go
+++ b/pkg/storage/backup_cache.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudprovider
+package storage
 
 import (
 	"context"

--- a/pkg/storage/backup_cache_test.go
+++ b/pkg/storage/backup_cache_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudprovider
+package storage
 
 import (
 	"context"

--- a/pkg/storage/object_storage_accessor.go
+++ b/pkg/storage/object_storage_accessor.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2018 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"io"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	arkv1api "github.com/heptio/ark/pkg/apis/ark/v1"
+	"github.com/heptio/ark/pkg/cloudprovider"
+	"github.com/heptio/ark/pkg/generated/clientset/versioned/scheme"
+)
+
+type objectStoreBackupAccessor struct {
+	objectStore cloudprovider.ObjectStore
+	bucket      string
+	prefix      string
+	backup      string
+	log         logrus.FieldLogger
+}
+
+var _ Accessor = &objectStoreBackupAccessor{}
+
+func (o *objectStoreBackupAccessor) SaveBackupLog(log io.Reader) error {
+	return seekAndPutObject(o.objectStore, o.bucket, getBackupLogKey(o.backup, o.backup), log)
+}
+
+func (o *objectStoreBackupAccessor) SaveBackupMetadata(backup io.Reader) error {
+	return seekAndPutObject(o.objectStore, o.bucket, getMetadataKey(o.backup), backup)
+}
+
+func (o *objectStoreBackupAccessor) DeleteBackupMetadata() error {
+	return o.objectStore.DeleteObject(o.bucket, getMetadataKey(o.backup))
+}
+
+func (o *objectStoreBackupAccessor) SaveBackupData(backup io.Reader) error {
+	return seekAndPutObject(o.objectStore, o.bucket, getBackupContentsKey(o.backup, o.backup), backup)
+}
+
+func (o *objectStoreBackupAccessor) SaveBackup(metadata, backup, log io.Reader) error {
+	if err := o.SaveBackupLog(log); err != nil {
+		// Uploading the log file is best-effort; if it fails, we log the error but it doesn't impact the
+		// backup's status.
+		o.log.WithError(err).WithField("bucket", o.bucket).Error("Error uploading log file")
+	}
+
+	if metadata == nil {
+		// If we don't have metadata, something failed, and there's no point in continuing. An object
+		// storage bucket that is missing the metadata file can't be restored, nor can its logs be
+		// viewed.
+		return nil
+	}
+
+	// upload metadata file
+	if err := o.SaveBackupMetadata(metadata); err != nil {
+		// failure to upload metadata file is a hard-stop
+		return err
+	}
+
+	// upload tar file
+	if err := o.SaveBackupData(backup); err != nil {
+		// try to delete the metadata file since the data upload failed
+		deleteErr := o.DeleteBackupMetadata()
+		return kerrors.NewAggregate([]error{err, deleteErr})
+	}
+
+	return nil
+}
+
+func (o *objectStoreBackupAccessor) GetBackupData() (io.ReadCloser, error) {
+	return o.objectStore.GetObject(o.bucket, getBackupContentsKey(o.backup, o.backup))
+}
+
+func (o *objectStoreBackupAccessor) GetBackupMetadata() (*arkv1api.Backup, error) {
+	key := getMetadataKey(o.backup)
+
+	res, err := o.objectStore.GetObject(o.bucket, key)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Close()
+
+	data, err := ioutil.ReadAll(res)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	decoder := scheme.Codecs.UniversalDecoder(arkv1api.SchemeGroupVersion)
+	obj, _, err := decoder.Decode(data, nil, nil)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	backup, ok := obj.(*arkv1api.Backup)
+	if !ok {
+		return nil, errors.Errorf("unexpected type for %s/%s: %T", o.bucket, key, obj)
+	}
+
+	return backup, nil
+}
+
+func (o *objectStoreBackupAccessor) DeleteBackup() error {
+	objects, err := o.objectStore.ListObjects(o.bucket, o.backup+"/")
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, key := range objects {
+		o.log.WithFields(logrus.Fields{
+			"bucket": o.bucket,
+			"key":    key,
+		}).Debug("Trying to delete object")
+		if err := o.objectStore.DeleteObject(o.bucket, key); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.WithStack(kerrors.NewAggregate(errs))
+}
+
+func (o *objectStoreBackupAccessor) SaveRestoreLog(restore string, log io.Reader) error {
+	return o.objectStore.PutObject(o.bucket, getRestoreLogKey(o.backup, restore), log)
+}
+
+func (o *objectStoreBackupAccessor) SaveRestoreResults(restore string, results io.Reader) error {
+	return o.objectStore.PutObject(o.bucket, getRestoreResultsKey(o.backup, restore), results)
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudprovider
+package storage
 
 import (
 	"fmt"
@@ -28,6 +28,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	api "github.com/heptio/ark/pkg/apis/ark/v1"
+	"github.com/heptio/ark/pkg/cloudprovider"
 	"github.com/heptio/ark/pkg/generated/clientset/versioned/scheme"
 )
 
@@ -75,7 +76,7 @@ func seekToBeginning(r io.Reader) error {
 	return err
 }
 
-func seekAndPutObject(objectStore ObjectStore, bucket, key string, file io.Reader) error {
+func seekAndPutObject(objectStore cloudprovider.ObjectStore, bucket, key string, file io.Reader) error {
 	if file == nil {
 		return nil
 	}
@@ -87,27 +88,27 @@ func seekAndPutObject(objectStore ObjectStore, bucket, key string, file io.Reade
 	return objectStore.PutObject(bucket, key, file)
 }
 
-func UploadBackupLog(objectStore ObjectStore, bucket, backupName string, log io.Reader) error {
+func UploadBackupLog(objectStore cloudprovider.ObjectStore, bucket, backupName string, log io.Reader) error {
 	logKey := getBackupLogKey(backupName, backupName)
 	return seekAndPutObject(objectStore, bucket, logKey, log)
 }
 
-func UploadBackupMetadata(objectStore ObjectStore, bucket, backupName string, metadata io.Reader) error {
+func UploadBackupMetadata(objectStore cloudprovider.ObjectStore, bucket, backupName string, metadata io.Reader) error {
 	metadataKey := getMetadataKey(backupName)
 	return seekAndPutObject(objectStore, bucket, metadataKey, metadata)
 }
 
-func DeleteBackupMetadata(objectStore ObjectStore, bucket, backupName string) error {
+func DeleteBackupMetadata(objectStore cloudprovider.ObjectStore, bucket, backupName string) error {
 	metadataKey := getMetadataKey(backupName)
 	return objectStore.DeleteObject(bucket, metadataKey)
 }
 
-func UploadBackupData(objectStore ObjectStore, bucket, backupName string, backup io.Reader) error {
+func UploadBackupData(objectStore cloudprovider.ObjectStore, bucket, backupName string, backup io.Reader) error {
 	backupKey := getBackupContentsKey(backupName, backupName)
 	return seekAndPutObject(objectStore, bucket, backupKey, backup)
 }
 
-func UploadBackup(logger logrus.FieldLogger, objectStore ObjectStore, bucket, backupName string, metadata, backup, log io.Reader) error {
+func UploadBackup(logger logrus.FieldLogger, objectStore cloudprovider.ObjectStore, bucket, backupName string, metadata, backup, log io.Reader) error {
 	if err := UploadBackupLog(objectStore, bucket, backupName, log); err != nil {
 		// Uploading the log file is best-effort; if it fails, we log the error but it doesn't impact the
 		// backup's status.
@@ -138,21 +139,21 @@ func UploadBackup(logger logrus.FieldLogger, objectStore ObjectStore, bucket, ba
 }
 
 // DownloadBackupFunc is a function that can download backup metadata from a bucket in object storage.
-type DownloadBackupFunc func(objectStore ObjectStore, bucket, backupName string) (io.ReadCloser, error)
+type DownloadBackupFunc func(objectStore cloudprovider.ObjectStore, bucket, backupName string) (io.ReadCloser, error)
 
 // DownloadBackup downloads an Ark backup with the specified object key from object storage via the cloud API.
 // It returns the snapshot metadata and data (separately), or an error if a problem is encountered
 // downloading or reading the file from the cloud API.
-func DownloadBackup(objectStore ObjectStore, bucket, backupName string) (io.ReadCloser, error) {
+func DownloadBackup(objectStore cloudprovider.ObjectStore, bucket, backupName string) (io.ReadCloser, error) {
 	return objectStore.GetObject(bucket, getBackupContentsKey(backupName, backupName))
 }
 
 type liveBackupLister struct {
 	logger      logrus.FieldLogger
-	objectStore ObjectStore
+	objectStore cloudprovider.ObjectStore
 }
 
-func NewLiveBackupLister(logger logrus.FieldLogger, objectStore ObjectStore) BackupLister {
+func NewLiveBackupLister(logger logrus.FieldLogger, objectStore cloudprovider.ObjectStore) BackupLister {
 	return &liveBackupLister{
 		logger:      logger,
 		objectStore: objectStore,
@@ -163,7 +164,7 @@ func (l *liveBackupLister) ListBackups(bucket string) ([]*api.Backup, error) {
 	return ListBackups(l.logger, l.objectStore, bucket)
 }
 
-func ListBackups(logger logrus.FieldLogger, objectStore ObjectStore, bucket string) ([]*api.Backup, error) {
+func ListBackups(logger logrus.FieldLogger, objectStore cloudprovider.ObjectStore, bucket string) ([]*api.Backup, error) {
 	prefixes, err := objectStore.ListCommonPrefixes(bucket, "/")
 	if err != nil {
 		return nil, err
@@ -188,10 +189,10 @@ func ListBackups(logger logrus.FieldLogger, objectStore ObjectStore, bucket stri
 }
 
 //GetBackupFunc is a function that can retrieve backup metadata from an object store
-type GetBackupFunc func(objectStore ObjectStore, bucket, backupName string) (*api.Backup, error)
+type GetBackupFunc func(objectStore cloudprovider.ObjectStore, bucket, backupName string) (*api.Backup, error)
 
 // GetBackup gets the specified api.Backup from the given bucket in object storage.
-func GetBackup(objectStore ObjectStore, bucket, backupName string) (*api.Backup, error) {
+func GetBackup(objectStore cloudprovider.ObjectStore, bucket, backupName string) (*api.Backup, error) {
 	key := getMetadataKey(backupName)
 
 	res, err := objectStore.GetObject(bucket, key)
@@ -220,10 +221,10 @@ func GetBackup(objectStore ObjectStore, bucket, backupName string) (*api.Backup,
 }
 
 // DeleteBackupDirFunc is a function that can delete a backup directory from a bucket in object storage.
-type DeleteBackupDirFunc func(logger logrus.FieldLogger, objectStore ObjectStore, bucket, backupName string) error
+type DeleteBackupDirFunc func(logger logrus.FieldLogger, objectStore cloudprovider.ObjectStore, bucket, backupName string) error
 
 // DeleteBackupDir deletes all files in object storage for the given backup.
-func DeleteBackupDir(logger logrus.FieldLogger, objectStore ObjectStore, bucket, backupName string) error {
+func DeleteBackupDir(logger logrus.FieldLogger, objectStore cloudprovider.ObjectStore, bucket, backupName string) error {
 	objects, err := objectStore.ListObjects(bucket, backupName+"/")
 	if err != nil {
 		return err
@@ -244,11 +245,11 @@ func DeleteBackupDir(logger logrus.FieldLogger, objectStore ObjectStore, bucket,
 }
 
 // CreateSignedURLFunc is a function that can create a signed URL for an object in object storage.
-type CreateSignedURLFunc func(objectStore ObjectStore, target api.DownloadTarget, bucket, directory string, ttl time.Duration) (string, error)
+type CreateSignedURLFunc func(objectStore cloudprovider.ObjectStore, target api.DownloadTarget, bucket, directory string, ttl time.Duration) (string, error)
 
 // CreateSignedURL creates a pre-signed URL that can be used to download a file from object
 // storage. The URL expires after ttl.
-func CreateSignedURL(objectStore ObjectStore, target api.DownloadTarget, bucket, directory string, ttl time.Duration) (string, error) {
+func CreateSignedURL(objectStore cloudprovider.ObjectStore, target api.DownloadTarget, bucket, directory string, ttl time.Duration) (string, error) {
 	switch target.Kind {
 	case api.DownloadTargetKindBackupContents:
 		return objectStore.CreateSignedURL(bucket, getBackupContentsKey(directory, target.Name), ttl)
@@ -264,19 +265,19 @@ func CreateSignedURL(objectStore ObjectStore, target api.DownloadTarget, bucket,
 }
 
 // UploadRestoreLogFunc is a function that can upload a restore log to a bucket in object storage.
-type UploadRestoreLogFunc func(objectStore ObjectStore, bucket, backup, restore string, log io.Reader) error
+type UploadRestoreLogFunc func(objectStore cloudprovider.ObjectStore, bucket, backup, restore string, log io.Reader) error
 
 // UploadRestoreLog uploads the restore's log file to object storage.
-func UploadRestoreLog(objectStore ObjectStore, bucket, backup, restore string, log io.Reader) error {
+func UploadRestoreLog(objectStore cloudprovider.ObjectStore, bucket, backup, restore string, log io.Reader) error {
 	key := getRestoreLogKey(backup, restore)
 	return objectStore.PutObject(bucket, key, log)
 }
 
 // UploadRestoreResultsFunc is a function that can upload restore results to a bucket in object storage.
-type UploadRestoreResultsFunc func(objectStore ObjectStore, bucket, backup, restore string, results io.Reader) error
+type UploadRestoreResultsFunc func(objectStore cloudprovider.ObjectStore, bucket, backup, restore string, results io.Reader) error
 
 // UploadRestoreResults uploads the restore's results file to object storage.
-func UploadRestoreResults(objectStore ObjectStore, bucket, backup, restore string, results io.Reader) error {
+func UploadRestoreResults(objectStore cloudprovider.ObjectStore, bucket, backup, restore string, results io.Reader) error {
 	key := getRestoreResultsKey(backup, restore)
 	return objectStore.PutObject(bucket, key, results)
 }

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudprovider
+package storage
 
 import (
 	"bytes"


### PR DESCRIPTION
I started looking at adding prefix support and that triggered some thoughts for refactoring around our ObjectStore and related code.

The third commit here is the interesting one (the first two are just moving existing code around).  The idea is that we add what amounts to a factory function - `BackupAccessor(...)`, which takes a `BackupStorageLocation` and other things, and returns an `Accessor`, which is an interface that can get/save/delete backups & related data from a storage backend.  This interface is implemented for an object storage backend, and reuses the code that was formerly known as `BackupService`.  If/when we add other backend types (git, filesystem, etc), we can add additional implementations easily, since the controllers are no longer tightly coupled to object storage as a backend.

Would appreciate thoughts on this.  @carlisia @nrb @ncdc 

This code is by no means complete, just implemented the interfaces, the object store implementation, and one example of how a controller/etc. would use this.

I also recognize that this will not by itself solve something like git - don't want to tackle all of that now.