### PR TITLE
add an ark bug command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ about: Tell us about a problem you are experiencing
 
 **Environment:**
 
-- Ark version (use `ark version`):
+- Ark version (use `ark version`):  
 - Kubernetes version (use `kubectl version`):
 - Kubernetes installer & version:
 - Cloud provider or hardware configuration:

--- a/docs/cli-reference/ark.md
+++ b/docs/cli-reference/ark.md
@@ -31,6 +31,7 @@ operations can also be performed as 'ark backup get' and 'ark schedule create'.
 
 ### SEE ALSO
 * [ark backup](ark_backup.md)	 - Work with backups
+* [ark bug](ark_bug.md)	 - Report an Ark bug
 * [ark client](ark_client.md)	 - Ark client related commands
 * [ark completion](ark_completion.md)	 - Output shell completion code for the specified shell (bash or zsh)
 * [ark create](ark_create.md)	 - Create ark resources

--- a/docs/cli-reference/ark_bug.md
+++ b/docs/cli-reference/ark_bug.md
@@ -1,0 +1,37 @@
+## ark bug
+
+Report an Ark bug
+
+### Synopsis
+
+
+Open a browser window to report an Ark bug
+
+```
+ark bug [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for bug
+```
+
+### Options inherited from parent commands
+
+```
+      --alsologtostderr                  log to standard error as well as files
+      --kubeconfig string                Path to the kubeconfig file to use to talk to the Kubernetes apiserver. If unset, try the environment variable KUBECONFIG, as well as in-cluster configuration
+      --kubecontext string               The context to use to talk to the Kubernetes apiserver. If unset defaults to whatever your current-context is (kubectl config current-context)
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files
+  -n, --namespace string                 The namespace in which Ark should operate (default "heptio-ark")
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+* [ark](ark.md)	 - Back up and restore Kubernetes cluster resources.
+

--- a/docs/issue-template-gen/main.go
+++ b/docs/issue-template-gen/main.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This code renders the IssueTemplate string in pkg/cmd/cli/bug/bug.go to
+// .github/ISSUE_TEMPLATE/bug_report.md via the hack/update-generated-issue-template.sh script.
+
+package main
+
+import (
+	"log"
+	"os"
+	"text/template"
+
+	"github.com/heptio/ark/pkg/cmd/cli/bug"
+)
+
+func main() {
+	outTemplateFilename := os.Args[1]
+	outFile, err := os.OpenFile(outTemplateFilename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer outFile.Close()
+	tmpl, err := template.New("ghissue").Parse(bug.IssueTemplate)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = tmpl.Execute(outFile, bug.ArkBugInfo{})
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,8 @@
 
 These tips can help you troubleshoot known issues. If they don't help, you can [file an issue][4], or talk to us on the [#ark-dr channel][25] on the Kubernetes Slack server. 
 
+In `ark` version >= `0.1.0`, you can use the `ark bug` command to open a [Github issue][4] by launching a browser window with some prepopulated values. Values included are OS, CPU architecture, `kubectl` client and server versions (if available) and the `ark` client version. This information isn't submitted to Github until you click the `Submit new issue` button in the Github UI, so feel free to add, remove or update whatever information you like.
+
 Some general commands for troubleshooting that may be helpful:
 
 * `ark backup describe <backupName>` - describe the details of a backup

--- a/hack/update-generated-issue-template.sh
+++ b/hack/update-generated-issue-template.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -e
+#
+# Copyright 2018 the Heptio Ark contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARK_ROOT=$(dirname ${BASH_SOURCE})/..
+BIN=${ARK_ROOT}/_output/bin
+
+mkdir -p ${BIN}
+
+echo "Updating generated Github issue template"
+go build -o ${BIN}/issue-tmpl-gen ./docs/issue-template-gen/main.go
+
+if [[ $# -gt 1 ]]; then
+  echo "usage: ${BASH_SOURCE} [OUTPUT_FILE]"
+  exit 1
+fi
+
+OUTPUT_ISSUE_FILE="$1"
+if [[ -z "${OUTPUT_ISSUE_FILE}" ]]; then
+  OUTPUT_ISSUE_FILE=${ARK_ROOT}/.github/ISSUE_TEMPLATE/bug_report.md
+fi
+
+${BIN}/issue-tmpl-gen ${OUTPUT_ISSUE_FILE} 
+echo "Success!"

--- a/hack/verify-generated-issue-template.sh
+++ b/hack/verify-generated-issue-template.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -e
+#
+# Copyright 2018 the Heptio Ark contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARK_ROOT=$(dirname ${BASH_SOURCE})/..
+HACK_DIR=$(dirname "${BASH_SOURCE}")
+ISSUE_TEMPLATE_FILE=${ARK_ROOT}/.github/ISSUE_TEMPLATE/bug_report.md
+OUT_TMP_FILE="$(mktemp -d)"/bug_report.md
+
+
+trap cleanup INT TERM HUP EXIT
+
+cleanup() {
+  rm -rf ${TMP_DIR}
+}
+
+echo "Verifying generated Github issue template"
+${HACK_DIR}/update-generated-issue-template.sh ${OUT_TMP_FILE} > /dev/null
+output=$(echo "`diff ${ISSUE_TEMPLATE_FILE} ${OUT_TMP_FILE}`")
+
+if [[ -n "${output}" ]] ; then
+    echo "FAILURE: verification of generated template failed:"
+    echo "${output}"
+    exit 1
+fi
+
+echo "Success!"

--- a/pkg/cmd/ark/ark.go
+++ b/pkg/cmd/ark/ark.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/heptio/ark/pkg/client"
 	"github.com/heptio/ark/pkg/cmd/cli/backup"
+	"github.com/heptio/ark/pkg/cmd/cli/bug"
 	cliclient "github.com/heptio/ark/pkg/cmd/cli/client"
 	"github.com/heptio/ark/pkg/cmd/cli/completion"
 	"github.com/heptio/ark/pkg/cmd/cli/create"
@@ -69,6 +70,7 @@ operations can also be performed as 'ark backup get' and 'ark schedule create'.`
 		cliclient.NewCommand(),
 		completion.NewCommand(),
 		restic.NewCommand(f),
+		bug.NewCommand(),
 	)
 
 	// add the glog flags


### PR DESCRIPTION
This PR adds the `ark bug` subcommand, which gathers a few bits of information and opens a new browser window with the Github issue template partially populated. 

- some of this is based on the existing `./hack/update-*` and `./hack/verify-*` scripts, so hopefully it's not too off base.
- The Github issue golang template is stored as a constant in `pkg/cmd/cli/bug/bug.go`. 
    - I experimented with using a standalone template file, but ran into a backtick escaping nightmare and ETOOCOMPLEX. 
- The `hack/update-generated-issue-template.sh` script renders the template (without populating any template vars) to `.github/ISSUE_TEMPLATE/bug_report.md`, and the `hack/verify-generated-issue-template.sh` will ensure that the `bug_report.md` file wasn't updated by hand. This will happen automatically during testing by way of `./hack/verify-all.sh`.
    - This means that changes to the [issue template](https://github.com/heptio/ark/blob/master/.github/ISSUE_TEMPLATE/bug_report.md) must be made in `pkg/cmd/cli/bug/bug.go`. 

- I realize that outside of the `./hack/verify-generated-issue-template.sh` script, there isn't any testing. I'm open to suggestions on ways to test this without jumping through too many hoops :-)

- I experimented with downloading the template, however I feel as though it's better to embed directly into the binary as the struct or the template itself could change and cause a mismatch between `ark` client versions. One way around this is to link a particular hosted version, but it seems like overkill. Also, it's hard to submit a PR that depends on a hosted file that's in the same PR :-)

- Eventually, this could include an ark server version via #770

see also https://github.com/heptio/ark/pull/713

Closes #578