### PR TITLE
backup sync: process the default location first

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -571,6 +571,7 @@ func (s *server) runControllers(config *api.Config, defaultBackupLocation *api.B
 		s.sharedInformerFactory.Ark().V1().BackupStorageLocations(),
 		s.config.backupSyncPeriod,
 		s.namespace,
+		s.config.defaultBackupLocation,
 		s.pluginRegistry,
 		s.logger,
 		s.logLevel,

--- a/pkg/controller/backup_sync_controller_test.go
+++ b/pkg/controller/backup_sync_controller_test.go
@@ -176,6 +176,7 @@ func TestBackupSyncControllerRun(t *testing.T) {
 				sharedInformers.Ark().V1().BackupStorageLocations(),
 				time.Duration(0),
 				test.namespace,
+				"",
 				nil, // pluginRegistry
 				arktest.NewLogger(),
 				logrus.DebugLevel,
@@ -341,6 +342,7 @@ func TestDeleteOrphanedBackups(t *testing.T) {
 				sharedInformers.Ark().V1().BackupStorageLocations(),
 				time.Duration(0),
 				test.namespace,
+				"",
 				nil, // pluginRegistry
 				arktest.NewLogger(),
 				logrus.InfoLevel,

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -521,6 +521,8 @@ func (c *restoreController) fetchFromBackupStorage(backupName string, pluginMana
 	return backupInfo{}, errors.New("not able to fetch from backup storage")
 }
 
+// orderedBackupLocations returns a new slice with the default backup location first (if it exists),
+// followed by the rest of the locations in no particular order.
 func orderedBackupLocations(locations []*api.BackupStorageLocation, defaultLocationName string) []*api.BackupStorageLocation {
 	var result []*api.BackupStorageLocation
 


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

Minor change to sync the default backup location first.  This is so that, in the interim before we robustly solve the issue with backup naming conflicts across locations, anything in `default` gets synced first.