### PR TITLE
Locations cleanup

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -67,7 +68,6 @@ import (
 	"github.com/heptio/ark/pkg/util/kube"
 	"github.com/heptio/ark/pkg/util/logging"
 	"github.com/heptio/ark/pkg/util/stringslice"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const (
@@ -222,7 +222,7 @@ func newServer(namespace, baseName string, config serverConfig, logger *logrus.L
 		arkClient:             arkClient,
 		discoveryClient:       arkClient.Discovery(),
 		dynamicClient:         dynamicClient,
-		sharedInformerFactory: informers.NewFilteredSharedInformerFactory(arkClient, 0, namespace, nil),
+		sharedInformerFactory: informers.NewSharedInformerFactoryWithOptions(arkClient, 0, informers.WithNamespace(namespace)),
 		ctx:            ctx,
 		cancelFunc:     cancelFunc,
 		logger:         logger,
@@ -486,13 +486,6 @@ func getBlockStore(cloudConfig api.CloudProviderConfig, manager plugin.Manager) 
 	}
 
 	return blockStore, nil
-}
-
-func durationMin(a, b time.Duration) time.Duration {
-	if a < b {
-		return a
-	}
-	return b
 }
 
 func (s *server) initRestic(providerName string) error {

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -178,7 +178,6 @@ func TestProcessBackup(t *testing.T) {
 				backupper       = &fakeBackupper{}
 				sharedInformers = informers.NewSharedInformerFactory(client, 0)
 				logger          = logging.DefaultLogger(logrus.DebugLevel)
-				pluginRegistry  = plugin.NewRegistry("/dir", logger, logrus.InfoLevel)
 				clockTime, _    = time.Parse("Mon Jan 2 15:04:05 2006", "Mon Jan 2 15:04:05 2006")
 				objectStore     = &arktest.ObjectStore{}
 				pluginManager   = &pluginmocks.Manager{}
@@ -194,7 +193,7 @@ func TestProcessBackup(t *testing.T) {
 				test.allowSnapshots,
 				logger,
 				logrus.InfoLevel,
-				pluginRegistry,
+				func(logrus.FieldLogger) plugin.Manager { return pluginManager },
 				NewBackupTracker(),
 				sharedInformers.Ark().V1().BackupStorageLocations(),
 				"default",
@@ -202,9 +201,6 @@ func TestProcessBackup(t *testing.T) {
 			).(*backupController)
 
 			c.clock = clock.NewFakeClock(clockTime)
-			c.newPluginManager = func(logger logrus.FieldLogger, logLevel logrus.Level, pluginRegistry plugin.Registry) plugin.Manager {
-				return pluginManager
-			}
 
 			var expiration, startTime time.Time
 

--- a/pkg/controller/backup_deletion_controller.go
+++ b/pkg/controller/backup_deletion_controller.go
@@ -66,7 +66,6 @@ type backupDeletionController struct {
 // NewBackupDeletionController creates a new backup deletion controller.
 func NewBackupDeletionController(
 	logger logrus.FieldLogger,
-	logLevel logrus.Level,
 	deleteBackupRequestInformer informers.DeleteBackupRequestInformer,
 	deleteBackupRequestClient arkv1client.DeleteBackupRequestsGetter,
 	backupClient arkv1client.BackupsGetter,
@@ -77,7 +76,7 @@ func NewBackupDeletionController(
 	resticMgr restic.RepositoryManager,
 	podvolumeBackupInformer informers.PodVolumeBackupInformer,
 	backupLocationInformer informers.BackupStorageLocationInformer,
-	pluginRegistry plugin.Registry,
+	newPluginManager func(logrus.FieldLogger) plugin.Manager,
 ) Interface {
 	c := &backupDeletionController{
 		genericController:         newGenericController("backup-deletion", logger),
@@ -94,10 +93,8 @@ func NewBackupDeletionController(
 
 		// use variables to refer to these functions so they can be
 		// replaced with fakes for testing.
-		deleteBackupDir: cloudprovider.DeleteBackupDir,
-		newPluginManager: func(logger logrus.FieldLogger) plugin.Manager {
-			return plugin.NewManager(logger, logLevel, pluginRegistry)
-		},
+		newPluginManager: newPluginManager,
+		deleteBackupDir:  cloudprovider.DeleteBackupDir,
 
 		clock: &clock.RealClock{},
 	}

--- a/pkg/controller/backup_deletion_controller_test.go
+++ b/pkg/controller/backup_deletion_controller_test.go
@@ -48,7 +48,6 @@ func TestBackupDeletionControllerProcessQueueItem(t *testing.T) {
 
 	controller := NewBackupDeletionController(
 		arktest.NewLogger(),
-		logrus.InfoLevel,
 		sharedInformers.Ark().V1().DeleteBackupRequests(),
 		client.ArkV1(), // deleteBackupRequestClient
 		client.ArkV1(), // backupClient
@@ -59,7 +58,7 @@ func TestBackupDeletionControllerProcessQueueItem(t *testing.T) {
 		nil, // restic repository manager
 		sharedInformers.Ark().V1().PodVolumeBackups(),
 		sharedInformers.Ark().V1().BackupStorageLocations(),
-		nil, // pluginRegistry
+		nil, // new plugin manager func
 	).(*backupDeletionController)
 
 	// Error splitting key
@@ -135,7 +134,6 @@ func setupBackupDeletionControllerTest(objects ...runtime.Object) *backupDeletio
 		objectStore:     objectStore,
 		controller: NewBackupDeletionController(
 			arktest.NewLogger(),
-			logrus.InfoLevel,
 			sharedInformers.Ark().V1().DeleteBackupRequests(),
 			client.ArkV1(), // deleteBackupRequestClient
 			client.ArkV1(), // backupClient
@@ -146,13 +144,11 @@ func setupBackupDeletionControllerTest(objects ...runtime.Object) *backupDeletio
 			nil, // restic repository manager
 			sharedInformers.Ark().V1().PodVolumeBackups(),
 			sharedInformers.Ark().V1().BackupStorageLocations(),
-			nil, // pluginRegistry
+			func(logrus.FieldLogger) plugin.Manager { return pluginManager },
 		).(*backupDeletionController),
 
 		req: req,
 	}
-
-	data.controller.newPluginManager = func(_ logrus.FieldLogger) plugin.Manager { return pluginManager }
 
 	pluginManager.On("GetObjectStore", "objStoreProvider").Return(objectStore, nil)
 	pluginManager.On("CleanupClients").Return(nil)
@@ -594,7 +590,6 @@ func TestBackupDeletionControllerDeleteExpiredRequests(t *testing.T) {
 
 			controller := NewBackupDeletionController(
 				arktest.NewLogger(),
-				logrus.InfoLevel,
 				sharedInformers.Ark().V1().DeleteBackupRequests(),
 				client.ArkV1(), // deleteBackupRequestClient
 				client.ArkV1(), // backupClient
@@ -605,7 +600,7 @@ func TestBackupDeletionControllerDeleteExpiredRequests(t *testing.T) {
 				nil,
 				sharedInformers.Ark().V1().PodVolumeBackups(),
 				sharedInformers.Ark().V1().BackupStorageLocations(),
-				nil, // pluginRegistry
+				nil, // new plugin manager func
 			).(*backupDeletionController)
 
 			fakeClock := &clock.FakeClock{}

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -57,9 +57,8 @@ func NewBackupSyncController(
 	syncPeriod time.Duration,
 	namespace string,
 	defaultBackupLocation string,
-	pluginRegistry plugin.Registry,
+	newPluginManager func(logrus.FieldLogger) plugin.Manager,
 	logger logrus.FieldLogger,
-	logLevel logrus.Level,
 ) Interface {
 	if syncPeriod < time.Minute {
 		logger.Infof("Provided backup sync period %v is too short. Setting to 1 minute", syncPeriod)
@@ -74,9 +73,9 @@ func NewBackupSyncController(
 		backupLister:                backupInformer.Lister(),
 		backupStorageLocationLister: backupStorageLocationInformer.Lister(),
 
-		newPluginManager: func(logger logrus.FieldLogger) plugin.Manager {
-			return plugin.NewManager(logger, logLevel, pluginRegistry)
-		},
+		// use variables to refer to these functions so they can be
+		// replaced with fakes for testing.
+		newPluginManager: newPluginManager,
 		listCloudBackups: cloudprovider.ListBackups,
 	}
 

--- a/pkg/controller/backup_sync_controller_test.go
+++ b/pkg/controller/backup_sync_controller_test.go
@@ -177,14 +177,13 @@ func TestBackupSyncControllerRun(t *testing.T) {
 				time.Duration(0),
 				test.namespace,
 				"",
-				nil, // pluginRegistry
+				func(logrus.FieldLogger) plugin.Manager { return pluginManager },
 				arktest.NewLogger(),
-				logrus.DebugLevel,
 			).(*backupSyncController)
 
-			c.newPluginManager = func(_ logrus.FieldLogger) plugin.Manager { return pluginManager }
 			pluginManager.On("GetObjectStore", "objStoreProvider").Return(objectStore, nil)
 			pluginManager.On("CleanupClients").Return(nil)
+
 			objectStore.On("Init", mock.Anything).Return(nil)
 
 			for _, location := range test.locations {
@@ -343,9 +342,8 @@ func TestDeleteOrphanedBackups(t *testing.T) {
 				time.Duration(0),
 				test.namespace,
 				"",
-				nil, // pluginRegistry
+				nil, // new plugin manager func
 				arktest.NewLogger(),
-				logrus.InfoLevel,
 			).(*backupSyncController)
 
 			expectedDeleteActions := make([]core.Action, 0)

--- a/pkg/controller/download_request_controller.go
+++ b/pkg/controller/download_request_controller.go
@@ -60,9 +60,8 @@ func NewDownloadRequestController(
 	restoreInformer informers.RestoreInformer,
 	backupLocationInformer informers.BackupStorageLocationInformer,
 	backupInformer informers.BackupInformer,
-	pluginRegistry plugin.Registry,
+	newPluginManager func(logrus.FieldLogger) plugin.Manager,
 	logger logrus.FieldLogger,
-	logLevel logrus.Level,
 ) Interface {
 	c := &downloadRequestController{
 		genericController:     newGenericController("downloadrequest", logger),
@@ -74,10 +73,8 @@ func NewDownloadRequestController(
 
 		// use variables to refer to these functions so they can be
 		// replaced with fakes for testing.
-		createSignedURL: cloudprovider.CreateSignedURL,
-		newPluginManager: func(logger logrus.FieldLogger) plugin.Manager {
-			return plugin.NewManager(logger, logLevel, pluginRegistry)
-		},
+		createSignedURL:  cloudprovider.CreateSignedURL,
+		newPluginManager: newPluginManager,
 
 		clock: &clock.RealClock{},
 	}

--- a/pkg/controller/download_request_controller_test.go
+++ b/pkg/controller/download_request_controller_test.go
@@ -59,9 +59,8 @@ func newDownloadRequestTestHarness(t *testing.T) *downloadRequestTestHarness {
 			informerFactory.Ark().V1().Restores(),
 			informerFactory.Ark().V1().BackupStorageLocations(),
 			informerFactory.Ark().V1().Backups(),
-			nil,
+			func(logrus.FieldLogger) plugin.Manager { return pluginManager },
 			arktest.NewLogger(),
-			logrus.InfoLevel,
 		).(*downloadRequestController)
 	)
 
@@ -69,8 +68,6 @@ func newDownloadRequestTestHarness(t *testing.T) *downloadRequestTestHarness {
 	require.NoError(t, err)
 
 	controller.clock = clock.NewFakeClock(clockTime)
-
-	controller.newPluginManager = func(_ logrus.FieldLogger) plugin.Manager { return pluginManager }
 
 	pluginManager.On("CleanupClients").Return()
 	objectStore.On("Init", mock.Anything).Return(nil)

--- a/pkg/controller/restore_controller_test.go
+++ b/pkg/controller/restore_controller_test.go
@@ -105,13 +105,10 @@ func TestFetchBackupInfo(t *testing.T) {
 				false,
 				logger,
 				logrus.InfoLevel,
-				nil, //pluginRegistry
+				func(logrus.FieldLogger) plugin.Manager { return pluginManager },
 				"default",
 				metrics.NewServerMetrics(),
 			).(*restoreController)
-			c.newPluginManager = func(logger logrus.FieldLogger, logLevel logrus.Level, pluginRegistry plugin.Registry) plugin.Manager {
-				return pluginManager
-			}
 
 			if test.backupServiceError == nil {
 				pluginManager.On("GetObjectStore", "myCloud").Return(objectStore, nil)
@@ -200,13 +197,10 @@ func TestProcessRestoreSkips(t *testing.T) {
 				false, // pvProviderExists
 				logger,
 				logrus.InfoLevel,
-				nil, // pluginRegistry
+				func(logrus.FieldLogger) plugin.Manager { return pluginManager },
 				"default",
 				metrics.NewServerMetrics(),
 			).(*restoreController)
-			c.newPluginManager = func(logger logrus.FieldLogger, logLevel logrus.Level, pluginRegistry plugin.Registry) plugin.Manager {
-				return pluginManager
-			}
 
 			if test.restore != nil {
 				sharedInformers.Ark().V1().Restores().Informer().GetStore().Add(test.restore)
@@ -427,13 +421,10 @@ func TestProcessRestore(t *testing.T) {
 				test.allowRestoreSnapshots,
 				logger,
 				logrus.InfoLevel,
-				nil, // pluginRegistry
+				func(logrus.FieldLogger) plugin.Manager { return pluginManager },
 				"default",
 				metrics.NewServerMetrics(),
 			).(*restoreController)
-			c.newPluginManager = func(logger logrus.FieldLogger, logLevel logrus.Level, pluginRegistry plugin.Registry) plugin.Manager {
-				return pluginManager
-			}
 
 			if test.location != nil {
 				sharedInformers.Ark().V1().BackupStorageLocations().Informer().GetStore().Add(test.location)


### PR DESCRIPTION
This PR does some minor cleanup on the backup-locations work.  The main change is to standardize/simplify how controllers construct a plugin manager.  They all now take a `newPluginManager` function pointer as an argument, that only requires a logger to be passed at execution time.