### PR TITLE
Claim ownership of new AWS volumes by Kubernetes cluster restoring the backup

### DIFF
--- a/docs/aws-config.md
+++ b/docs/aws-config.md
@@ -151,6 +151,31 @@ Specify the following values in the example files:
 
     * Replace `<YOUR_STORAGE_CLASS_NAME>` with `gp2`. This is AWS's default `StorageClass` name.
 
+* (Optional) If you have multiple clusters and you want to support migration of resources between them, in file `examples/aws/10-deployment.yaml`:
+
+    * Uncomment the environment variable `AWS_CLUSTER_NAME` and replace `<YOUR_CLUSTER_NAME>` with the current cluster's name. When restoring backup, it will make Ark (and cluster it's running on) claim ownership of AWS volumes created from snapshots taken on different cluster.
+    The best way to get the current cluster's name is to either check it with used deployment tool or to read it directly from the EC2 instances tags. 
+    
+      The following listing shows how to get the cluster's nodes EC2 Tags. First, get the nodes external IDs (EC2 IDs):
+
+        ```bash
+        kubectl get nodes -o jsonpath='{.items[*].spec.externalID}'
+        ```
+    
+      Copy one of the returned IDs `<ID>` and use it with the `aws` CLI tool to search for one of the following:
+
+      * The `kubernetes.io/cluster/<AWS_CLUSTER_NAME>` tag of the value `owned`. The `<AWS_CLUSTER_NAME>` is then your cluster's name:
+
+          ```bash
+          aws ec2 describe-tags --filters "Name=resource-id,Values=<ID>" "Name=value,Values=owned"
+          ```
+    
+      * If the first output returns nothing, then check for the legacy Tag `KubernetesCluster` of the value `<AWS_CLUSTER_NAME>`:
+
+          ```bash
+          aws ec2 describe-tags --filters "Name=resource-id,Values=<ID>" "Name=key,Values=KubernetesCluster"
+        ```
+
 ## Start the server
 
 In the root of your Ark directory, run:

--- a/examples/aws/10-deployment.yaml
+++ b/examples/aws/10-deployment.yaml
@@ -50,6 +50,8 @@ spec:
               value: /credentials/cloud
             - name: ARK_SCRATCH_DIR
               value: /scratch
+            #- name: AWS_CLUSTER_NAME
+            #  value: <YOUR_CLUSTER_NAME>
       volumes:
         - name: cloud-credentials
           secret:

--- a/pkg/cloudprovider/aws/block_store_test.go
+++ b/pkg/cloudprovider/aws/block_store_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aws
 
 import (
+	"os"
 	"sort"
 	"testing"
 
@@ -89,6 +90,91 @@ func TestSetVolumeID(t *testing.T) {
 	actual, err := collections.GetString(updatedPV.UnstructuredContent(), "spec.awsElasticBlockStore.volumeID")
 	require.NoError(t, err)
 	assert.Equal(t, "vol-updated", actual)
+}
+
+func TestGetTagsForCluster(t *testing.T) {
+	tests := []struct {
+		name         string
+		isNameSet    bool
+		snapshotTags []*ec2.Tag
+		expected     []*ec2.Tag
+	}{
+		{
+			name:         "degenerate case (no tags)",
+			isNameSet:    false,
+			snapshotTags: nil,
+			expected:     nil,
+		},
+		{
+			name:      "cluster tags exist and remain set",
+			isNameSet: false,
+			snapshotTags: []*ec2.Tag{
+				ec2Tag("KubernetesCluster", "old-cluster"),
+				ec2Tag("kubernetes.io/cluster/old-cluster", "owned"),
+				ec2Tag("aws-key", "aws-val"),
+			},
+			expected: []*ec2.Tag{
+				ec2Tag("KubernetesCluster", "old-cluster"),
+				ec2Tag("kubernetes.io/cluster/old-cluster", "owned"),
+				ec2Tag("aws-key", "aws-val"),
+			},
+		},
+		{
+			name:         "cluster tags only get applied",
+			isNameSet:    true,
+			snapshotTags: nil,
+			expected: []*ec2.Tag{
+				ec2Tag("KubernetesCluster", "current-cluster"),
+				ec2Tag("kubernetes.io/cluster/current-cluster", "owned"),
+			},
+		},
+		{
+			name:         "non-overlaping cluster and snapshot tags both get applied",
+			isNameSet:    true,
+			snapshotTags: []*ec2.Tag{ec2Tag("aws-key", "aws-val")},
+			expected: []*ec2.Tag{
+				ec2Tag("KubernetesCluster", "current-cluster"),
+				ec2Tag("kubernetes.io/cluster/current-cluster", "owned"),
+				ec2Tag("aws-key", "aws-val"),
+			},
+		},
+		{name: "overlaping cluster tags, current cluster tags take precedence",
+			isNameSet: true,
+			snapshotTags: []*ec2.Tag{
+				ec2Tag("KubernetesCluster", "old-name"),
+				ec2Tag("kubernetes.io/cluster/old-name", "owned"),
+				ec2Tag("aws-key", "aws-val"),
+			},
+			expected: []*ec2.Tag{
+				ec2Tag("KubernetesCluster", "current-cluster"),
+				ec2Tag("kubernetes.io/cluster/current-cluster", "owned"),
+				ec2Tag("aws-key", "aws-val"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.isNameSet {
+				os.Setenv("AWS_CLUSTER_NAME", "current-cluster")
+			}
+			res := getTagsForCluster(test.snapshotTags)
+
+			sort.Slice(res, func(i, j int) bool {
+				return *res[i].Key < *res[j].Key
+			})
+
+			sort.Slice(test.expected, func(i, j int) bool {
+				return *test.expected[i].Key < *test.expected[j].Key
+			})
+
+			assert.Equal(t, test.expected, res)
+
+			if test.isNameSet {
+				os.Unsetenv("AWS_CLUSTER_NAME")
+			}
+		})
+	}
 }
 
 func TestGetTags(t *testing.T) {


### PR DESCRIPTION
This PR adds very simple support for tagging the cloud snapshots when taking a backup. These tags are further inherited by the volumes created from snapshots when restoring the backup. This may be helpful when migrating resources between two different k8s clusters, where the 2nd one expects certain tagging scheme in order to utilize volumes as PVs, especially in case of backing up large releases/number of resources. An example of such use-case may be the Kops clusters on AWS that creates and expects _KubernetesCluster=<name>_ Tag on volumes. Although it does not seem to be a very common case, having support for tagging in place may prove to be useful time-saver when restoring a backup.

What do you think of this? Does it make any sense? If it does but I'm getting ahead of myself by submitting this PR without creating an issue I will change it to the appropriate issue/request.