### PR TITLE
Set schedule labels to subsequent backups

### DIFF
--- a/pkg/cmd/cli/schedule/create.go
+++ b/pkg/cmd/cli/schedule/create.go
@@ -104,6 +104,7 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: f.Namespace(),
 			Name:      o.BackupOptions.Name,
+			Labels:    o.BackupOptions.Labels.Data(),
 		},
 		Spec: api.ScheduleSpec{
 			Template: api.BackupSpec{

--- a/pkg/controller/schedule_controller.go
+++ b/pkg/controller/schedule_controller.go
@@ -370,13 +370,23 @@ func getBackup(item *api.Schedule, timestamp time.Time) *api.Backup {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: item.Namespace,
 			Name:      fmt.Sprintf("%s-%s", item.Name, timestamp.Format("20060102150405")),
-			Labels: map[string]string{
-				"ark-schedule": item.Name,
-			},
 		},
 	}
 
+	// add schedule labels and 'ark-schedule' label to the backup
+	addLabelsToBackup(item, backup)
+
 	return backup
+}
+
+func addLabelsToBackup(item *api.Schedule, backup *api.Backup) {
+	labels := item.Labels
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels["ark-schedule"] = item.Name
+
+	backup.Labels = labels
 }
 
 func patchSchedule(original, updated *api.Schedule, client arkv1client.SchedulesGetter) (*api.Schedule, error) {

--- a/pkg/controller/schedule_controller_test.go
+++ b/pkg/controller/schedule_controller_test.go
@@ -403,6 +403,9 @@ func TestGetBackup(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "foo",
 					Name:      "bar-20170725091500",
+					Labels: map[string]string{
+						"ark-schedule": "bar",
+					},
 				},
 				Spec: api.BackupSpec{},
 			},
@@ -423,6 +426,9 @@ func TestGetBackup(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "foo",
 					Name:      "bar-20170725141500",
+					Labels: map[string]string{
+						"ark-schedule": "bar",
+					},
 				},
 				Spec: api.BackupSpec{},
 			},
@@ -450,6 +456,9 @@ func TestGetBackup(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "foo",
 					Name:      "bar-20170725091500",
+					Labels: map[string]string{
+						"ark-schedule": "bar",
+					},
 				},
 				Spec: api.BackupSpec{
 					IncludedNamespaces: []string{"ns-1", "ns-2"},
@@ -459,6 +468,35 @@ func TestGetBackup(t *testing.T) {
 					LabelSelector:      &metav1.LabelSelector{MatchLabels: map[string]string{"label": "value"}},
 					TTL:                metav1.Duration{Duration: time.Duration(300)},
 				},
+			},
+		},
+		{
+			name: "ensure schedule labels is copied",
+			schedule: &api.Schedule{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar",
+					Labels: map[string]string{
+						"foo": "bar",
+						"bar": "baz",
+					},
+				},
+				Spec: api.ScheduleSpec{
+					Template: api.BackupSpec{},
+				},
+			},
+			testClockTime: "2017-07-25 14:15:00",
+			expectedBackup: &api.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar-20170725141500",
+					Labels: map[string]string{
+						"ark-schedule": "bar",
+						"bar":          "baz",
+						"foo":          "bar",
+					},
+				},
+				Spec: api.BackupSpec{},
 			},
 		},
 	}
@@ -472,6 +510,7 @@ func TestGetBackup(t *testing.T) {
 
 			assert.Equal(t, test.expectedBackup.Namespace, backup.Namespace)
 			assert.Equal(t, test.expectedBackup.Name, backup.Name)
+			assert.Equal(t, test.expectedBackup.Labels, backup.Labels)
 			assert.Equal(t, test.expectedBackup.Spec, backup.Spec)
 		})
 	}


### PR DESCRIPTION
It would be nice to have labels on backups created by a schedule. This PR sets the labels a schedule has to the subsequent backups.