### PR TITLE
set azure restic env vars based on default backup location's config

### DIFF
--- a/docs/cli-reference/ark_restic_server.md
+++ b/docs/cli-reference/ark_restic_server.md
@@ -13,8 +13,9 @@ ark restic server [flags]
 ### Options
 
 ```
-  -h, --help        help for server
-      --log-level   the level at which to log. Valid values are debug, info, warning, error, fatal, panic. (default info)
+      --default-backup-storage-location string   name of the default backup storage location (default "default")
+  -h, --help                                     help for server
+      --log-level                                the level at which to log. Valid values are debug, info, warning, error, fatal, panic. (default info)
 ```
 
 ### Options inherited from parent commands

--- a/examples/azure/20-restic-daemonset.yaml
+++ b/examples/azure/20-restic-daemonset.yaml
@@ -61,15 +61,5 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: AZURE_ACCOUNT_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: cloud-credentials
-                  key: AZURE_STORAGE_ACCOUNT_ID
-            - name: AZURE_ACCOUNT_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: cloud-credentials
-                  key: AZURE_STORAGE_KEY
             - name: ARK_SCRATCH_DIR
               value: /scratch

--- a/pkg/cloudprovider/azure/common.go
+++ b/pkg/cloudprovider/azure/common.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azure
 
 import (
+	"os"
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest/adal"
@@ -30,6 +31,21 @@ const (
 	clientIDEnvVar       = "AZURE_CLIENT_ID"
 	clientSecretEnvVar   = "AZURE_CLIENT_SECRET"
 )
+
+// SetResticEnvVars sets the environment variables that restic
+// relies on (AZURE_ACCOUNT_NAME and AZURE_ACCOUNT_KEY) based
+// on info in the provided object storage location config map.
+func SetResticEnvVars(config map[string]string) error {
+	os.Setenv("AZURE_ACCOUNT_NAME", config[storageAccountConfigKey])
+
+	storageAccountKey, err := getStorageAccountKey(config)
+	if err != nil {
+		return err
+	}
+	os.Setenv("AZURE_ACCOUNT_KEY", storageAccountKey)
+
+	return nil
+}
 
 func newServicePrincipalToken(tenantID, clientID, clientSecret, scope string) (*adal.ServicePrincipalToken, error) {
 	oauthConfig, err := adal.NewOAuthConfig(azure.PublicCloud.ActiveDirectoryEndpoint, tenantID)


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

The location-related changes to Azure to support multiple storage accounts broke restic support on Azure, because storage accounts/keys are no longer static config values.  This PR fixes the restic integration.

Note that this is likely a short-term fix, since we'll be adding multi-location support for restic as well. But in the interim, this keeps it working.