### PR TITLE
Discard all SA Token volumes from pod restore

### DIFF
--- a/pkg/restore/merge_service_account.go
+++ b/pkg/restore/merge_service_account.go
@@ -47,8 +47,8 @@ func mergeServiceAccounts(fromCluster, fromBackup *unstructured.Unstructured) (*
 
 	for i := len(backupSA.Secrets) - 1; i >= 0; i-- {
 		secret := &backupSA.Secrets[i]
-		if strings.HasPrefix(secret.Name, "default-token-") {
-			// Copy all secrets *except* default-token
+		if strings.HasPrefix(secret.Name, backupSA.Name+"-token-") {
+			// Copy all secrets *except* -token-
 			backupSA.Secrets = append(backupSA.Secrets[:i], backupSA.Secrets[i+1:]...)
 			break
 		}

--- a/pkg/restore/pod_action.go
+++ b/pkg/restore/pod_action.go
@@ -17,7 +17,7 @@ limitations under the License.
 package restore
 
 import (
-	"regexp"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -41,10 +41,6 @@ func (a *podAction) AppliesTo() (ResourceSelector, error) {
 	}, nil
 }
 
-var (
-	defaultTokenRegex = regexp.MustCompile("default-token-.*")
-)
-
 func (a *podAction) Execute(obj runtime.Unstructured, restore *api.Restore) (runtime.Unstructured, error, error) {
 	a.logger.Debug("getting spec")
 	spec, err := collections.GetMap(obj.UnstructuredContent(), "spec")
@@ -55,6 +51,11 @@ func (a *podAction) Execute(obj runtime.Unstructured, restore *api.Restore) (run
 	a.logger.Debug("deleting spec.NodeName")
 	delete(spec, "nodeName")
 
+	serviceAccountName, err := collections.GetString(spec, "serviceAccountName")
+	if err != nil {
+		return nil, nil, err
+	}
+
 	newVolumes := make([]interface{}, 0)
 	a.logger.Debug("iterating over volumes")
 	err = collections.ForEach(spec, "volumes", func(volume map[string]interface{}) error {
@@ -64,11 +65,11 @@ func (a *podAction) Execute(obj runtime.Unstructured, restore *api.Restore) (run
 		}
 
 		a.logger.WithField("volumeName", name).Debug("Checking volume")
-		if !defaultTokenRegex.MatchString(name) {
+		if strings.HasPrefix(name, serviceAccountName+"-token-") {
+			a.logger.WithField("volumeName", name).Debug("Excluding volume")
+		} else {
 			a.logger.WithField("volumeName", name).Debug("Preserving volume")
 			newVolumes = append(newVolumes, volume)
-		} else {
-			a.logger.WithField("volumeName", name).Debug("Excluding volume")
 		}
 
 		return nil
@@ -90,11 +91,11 @@ func (a *podAction) Execute(obj runtime.Unstructured, restore *api.Restore) (run
 			}
 
 			a.logger.WithField("volumeMount", name).Debug("Checking volumeMount")
-			if !defaultTokenRegex.MatchString(name) {
+			if strings.HasPrefix(name, serviceAccountName+"-token-") {
+				a.logger.WithField("volumeMount", name).Debug("Excluding volumeMount")
+			} else {
 				a.logger.WithField("volumeMount", name).Debug("Preserving volumeMount")
 				newVolumeMounts = append(newVolumeMounts, volumeMount)
-			} else {
-				a.logger.WithField("volumeMount", name).Debug("Excluding volumeMount")
 			}
 
 			return nil

--- a/pkg/restore/pod_action_test.go
+++ b/pkg/restore/pod_action_test.go
@@ -40,31 +40,36 @@ func TestPodActionExecute(t *testing.T) {
 		{
 			name: "nodeName (only) should be deleted from spec",
 			obj: NewTestUnstructured().WithName("pod-1").WithSpec("nodeName", "foo").
+				WithSpec("serviceAccountName", "foo").
 				WithSpecField("volumes", []interface{}{}).
 				WithSpecField("containers", []interface{}{}).
 				Unstructured,
 			expectedErr: false,
 			expectedRes: NewTestUnstructured().WithName("pod-1").WithSpec("foo").
+				WithSpec("serviceAccountName", "foo").
 				WithSpecField("volumes", []interface{}{}).
 				WithSpecField("containers", []interface{}{}).
 				Unstructured,
 		},
 		{
-			name: "volumes matching default-token regex should be deleted",
+			name: "volumes matching prefix ServiceAccount-token- should be deleted",
 			obj: NewTestUnstructured().WithName("pod-1").
+				WithSpec("serviceAccountName", "foo").
 				WithSpecField("volumes", []interface{}{
 					map[string]interface{}{"name": "foo"},
-					map[string]interface{}{"name": "default-token-foo"},
+					map[string]interface{}{"name": "foo-token-foo"},
 				}).WithSpecField("containers", []interface{}{}).Unstructured,
 			expectedErr: false,
 			expectedRes: NewTestUnstructured().WithName("pod-1").
+				WithSpec("serviceAccountName", "foo").
 				WithSpecField("volumes", []interface{}{
 					map[string]interface{}{"name": "foo"},
 				}).WithSpecField("containers", []interface{}{}).Unstructured,
 		},
 		{
-			name: "container volumeMounts matching default-token regex should be deleted",
+			name: "container volumeMounts matching prefix ServiceAccount-token- should be deleted",
 			obj: NewTestUnstructured().WithName("svc-1").
+				WithSpec("serviceAccountName", "foo").
 				WithSpecField("volumes", []interface{}{}).
 				WithSpecField("containers", []interface{}{
 					map[string]interface{}{
@@ -73,7 +78,7 @@ func TestPodActionExecute(t *testing.T) {
 								"name": "foo",
 							},
 							map[string]interface{}{
-								"name": "default-token-foo",
+								"name": "foo-token-foo",
 							},
 						},
 					},
@@ -81,6 +86,7 @@ func TestPodActionExecute(t *testing.T) {
 				Unstructured,
 			expectedErr: false,
 			expectedRes: NewTestUnstructured().WithName("svc-1").
+				WithSpec("serviceAccountName", "foo").
 				WithSpecField("volumes", []interface{}{}).
 				WithSpecField("containers", []interface{}{
 					map[string]interface{}{


### PR DESCRIPTION
Addresses #840 

SA Tokens are dynamically defined and auto attributed when ServiceAccountName is attributed to the pod. As such these should be safe to remove from the restore. To be doubly sure we are only deleting the secret from the restore if it matches ${serviceAccountName}-token-