### PR TITLE
Bump alpine image for security fix

### DIFF
--- a/Dockerfile-ark-restic-restore-helper.alpine
+++ b/Dockerfile-ark-restic-restore-helper.alpine
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.7
+FROM alpine:3.8
 
 MAINTAINER Steve Kriss <steve@heptio.com>
 

--- a/Dockerfile-ark.alpine
+++ b/Dockerfile-ark.alpine
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.7
+FROM alpine:3.8
 
 MAINTAINER Andy Goldstein <andy@heptio.com>
 

--- a/Dockerfile-fsfreeze-pause.alpine
+++ b/Dockerfile-fsfreeze-pause.alpine
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.7
+FROM alpine:3.8
 
 MAINTAINER Wayne Witzel III <wayne@heptio.com>
 

--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.10-alpine3.7
+FROM golang:1.10-alpine3.8
 
 RUN apk add --update --no-cache git bash && \
     mkdir -p /go/src/k8s.io && \


### PR DESCRIPTION
This change includes the fix at https://github.com/docker-library/official-images/pull/4834

Signed-off-by: Nolan Brubaker <nolan@heptio.com>