### PR TITLE
Fix infinite sleep in fsfreeze container

### DIFF
--- a/Dockerfile-fsfreeze-pause.alpine
+++ b/Dockerfile-fsfreeze-pause.alpine
@@ -19,4 +19,4 @@ MAINTAINER Wayne Witzel III <wayne@heptio.com>
 RUN apk add --no-cache ca-certificates
 RUN apk add --update --no-cache busybox util-linux
 
-ENTRYPOINT ["/bin/sh", "-c", "sleep infinity"]
+ENTRYPOINT ["/bin/sh", "-c", "while true; do sleep 10000; done"]


### PR DESCRIPTION
busybox's sleep command doesn't support the `infinity` value, so update
it to be an infinite loop.

Signed-off-by: Nolan Brubaker <nolan@heptio.com>