### PR TITLE
add create CLI command for snapshot locations

### DIFF
--- a/docs/cli-reference/ark_snapshot-location_create.md
+++ b/docs/cli-reference/ark_snapshot-location_create.md
@@ -1,15 +1,25 @@
-## ark snapshot-location
+## ark snapshot-location create
 
-Work with snapshot locations
+Create a volume snapshot location
 
 ### Synopsis
 
-Work with snapshot locations
+Create a volume snapshot location
+
+```
+ark snapshot-location create NAME [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for snapshot-location
+      --config mapStringString      configuration key-value pairs
+  -h, --help                        help for create
+      --label-columns stringArray   a comma-separated list of labels to be displayed as columns
+      --labels mapStringString      labels to apply to the volume snapshot location
+  -o, --output string               Output display format. For create commands, display the object but do not send it to the server. Valid formats are 'table', 'json', and 'yaml'.
+      --provider string             name of the volume snapshot provider (e.g. aws, azure, gcp)
+      --show-labels                 show labels in the last column
 ```
 
 ### Options inherited from parent commands
@@ -29,7 +39,5 @@ Work with snapshot locations
 
 ### SEE ALSO
 
-* [ark](ark.md)	 - Back up and restore Kubernetes cluster resources.
-* [ark snapshot-location create](ark_snapshot-location_create.md)	 - Create a volume snapshot location
-* [ark snapshot-location get](ark_snapshot-location_get.md)	 - Get snapshot locations
+* [ark snapshot-location](ark_snapshot-location.md)	 - Work with snapshot locations
 

--- a/pkg/cmd/cli/snapshotlocation/create.go
+++ b/pkg/cmd/cli/snapshotlocation/create.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2018 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshotlocation
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	api "github.com/heptio/ark/pkg/apis/ark/v1"
+	"github.com/heptio/ark/pkg/client"
+	"github.com/heptio/ark/pkg/cmd"
+	"github.com/heptio/ark/pkg/cmd/util/flag"
+	"github.com/heptio/ark/pkg/cmd/util/output"
+)
+
+func NewCreateCommand(f client.Factory, use string) *cobra.Command {
+	o := NewCreateOptions()
+
+	c := &cobra.Command{
+		Use:   use + " NAME",
+		Short: "Create a volume snapshot location",
+		Args:  cobra.ExactArgs(1),
+		Run: func(c *cobra.Command, args []string) {
+			cmd.CheckError(o.Complete(args, f))
+			cmd.CheckError(o.Validate(c, args, f))
+			cmd.CheckError(o.Run(c, f))
+		},
+	}
+
+	o.BindFlags(c.Flags())
+	output.BindFlags(c.Flags())
+	output.ClearOutputFlagDefault(c)
+
+	return c
+}
+
+type CreateOptions struct {
+	Name     string
+	Provider string
+	Config   flag.Map
+	Labels   flag.Map
+}
+
+func NewCreateOptions() *CreateOptions {
+	return &CreateOptions{
+		Config: flag.NewMap(),
+	}
+}
+
+func (o *CreateOptions) BindFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&o.Provider, "provider", o.Provider, "name of the volume snapshot provider (e.g. aws, azure, gcp)")
+	flags.Var(&o.Config, "config", "configuration key-value pairs")
+	flags.Var(&o.Labels, "labels", "labels to apply to the volume snapshot location")
+}
+
+func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Factory) error {
+	if err := output.ValidateFlags(c); err != nil {
+		return err
+	}
+
+	if o.Provider == "" {
+		return errors.New("--provider is required")
+	}
+
+	return nil
+}
+
+func (o *CreateOptions) Complete(args []string, f client.Factory) error {
+	o.Name = args[0]
+	return nil
+}
+
+func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
+	volumeSnapshotLocation := &api.VolumeSnapshotLocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: f.Namespace(),
+			Name:      o.Name,
+			Labels:    o.Labels.Data(),
+		},
+		Spec: api.VolumeSnapshotLocationSpec{
+			Provider: o.Provider,
+			Config:   o.Config.Data(),
+		},
+	}
+
+	if printed, err := output.PrintWithFormat(c, volumeSnapshotLocation); printed || err != nil {
+		return err
+	}
+
+	client, err := f.Client()
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.ArkV1().VolumeSnapshotLocations(volumeSnapshotLocation.Namespace).Create(volumeSnapshotLocation); err != nil {
+		return errors.WithStack(err)
+	}
+
+	fmt.Printf("Snapshot volume location %q configured successfully.\n", volumeSnapshotLocation.Name)
+	return nil
+}

--- a/pkg/cmd/cli/snapshotlocation/snapshot_location.go
+++ b/pkg/cmd/cli/snapshotlocation/snapshot_location.go
@@ -30,6 +30,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 	}
 
 	c.AddCommand(
+		NewCreateCommand(f, "create"),
 		NewGetCommand(f, "get"),
 	)
 


### PR DESCRIPTION
Signed-off-by: Wayne Witzel III <wayne@riotousliving.com>

Fixes #802 

I did not add the generated docs from `make update` because #868 as recently merged and those are going away anyway.