### PR TITLE
Change CreationTimestamp to StartTimestamp in backup list

### DIFF
--- a/pkg/cmd/util/output/backup_printer.go
+++ b/pkg/cmd/util/output/backup_printer.go
@@ -94,7 +94,7 @@ func printBackup(backup *arkv1api.Backup, w io.Writer, options printers.PrintOpt
 
 	location := backup.Spec.StorageLocation
 
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s", name, status, backup.CreationTimestamp.Time, humanReadableTimeFromNow(expiration), location, metav1.FormatLabelSelector(backup.Spec.LabelSelector)); err != nil {
+	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s", name, status, backup.Status.StartTimestamp.Time, humanReadableTimeFromNow(expiration), location, metav1.FormatLabelSelector(backup.Spec.LabelSelector)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes #883.

Using `CreationTimestamp`,

```
$ ark backup get

NAME                            STATUS      CREATED                          EXPIRES   SELECTOR
staging-backup-20181002120026   Completed   2018-10-02 14:50:30 +0200 CEST   29d       <none>
staging-backup-20181001120048   Completed   2018-10-02 14:50:30 +0200 CEST   28d       <none>
staging-backup-20180930120054   Completed   2018-10-02 14:50:30 +0200 CEST   27d       <none>
staging-backup-20180929120023   Completed   2018-10-02 14:50:30 +0200 CEST   26d       <none>
staging-backup-20180928125316   Completed   2018-10-02 14:50:30 +0200 CEST   25d       <none>
```

Using `StartTimestamp`,
```
$ ./ark backup get

NAME                            STATUS      CREATED                          EXPIRES   STORAGE LOCATION   SELECTOR

staging-backup-20181002120026   Completed   2018-10-02 14:00:27 +0200 CEST   29d                          <none>
staging-backup-20181001120048   Completed   2018-10-01 14:00:48 +0200 CEST   28d                          <none>
staging-backup-20180930120054   Completed   2018-09-30 14:00:54 +0200 CEST   27d                          <none>
staging-backup-20180929120023   Completed   2018-09-29 14:00:23 +0200 CEST   26d                          <none>
staging-backup-20180928125316   Completed   2018-09-28 14:53:16 +0200 CEST   25d                          <none>
```

Should we need to change the name of the column too? Is there any place that this needs to be changed?