### PR TITLE
Update backups for volume snapshot locations

### DIFF
--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -40,58 +40,48 @@ import (
 	"github.com/heptio/ark/pkg/kuberesource"
 	"github.com/heptio/ark/pkg/podexec"
 	"github.com/heptio/ark/pkg/restic"
-	"github.com/heptio/ark/pkg/util/collections"
 )
 
 type itemBackupperFactory interface {
 	newItemBackupper(
-		backup *api.Backup,
-		namespaces, resources *collections.IncludesExcludes,
+		backup *Request,
 		backedUpItems map[itemKey]struct{},
-		actions []resolvedAction,
 		podCommandExecutor podexec.PodCommandExecutor,
 		tarWriter tarWriter,
-		resourceHooks []resourceHook,
 		dynamicFactory client.DynamicFactory,
 		discoveryHelper discovery.Helper,
-		blockStore cloudprovider.BlockStore,
 		resticBackupper restic.Backupper,
 		resticSnapshotTracker *pvcSnapshotTracker,
+		blockStoreGetter BlockStoreGetter,
 	) ItemBackupper
 }
 
 type defaultItemBackupperFactory struct{}
 
 func (f *defaultItemBackupperFactory) newItemBackupper(
-	backup *api.Backup,
-	namespaces, resources *collections.IncludesExcludes,
+	backupRequest *Request,
 	backedUpItems map[itemKey]struct{},
-	actions []resolvedAction,
 	podCommandExecutor podexec.PodCommandExecutor,
 	tarWriter tarWriter,
-	resourceHooks []resourceHook,
 	dynamicFactory client.DynamicFactory,
 	discoveryHelper discovery.Helper,
-	blockStore cloudprovider.BlockStore,
 	resticBackupper restic.Backupper,
 	resticSnapshotTracker *pvcSnapshotTracker,
+	blockStoreGetter BlockStoreGetter,
 ) ItemBackupper {
 	ib := &defaultItemBackupper{
-		backup:          backup,
-		namespaces:      namespaces,
-		resources:       resources,
-		backedUpItems:   backedUpItems,
-		actions:         actions,
-		tarWriter:       tarWriter,
-		resourceHooks:   resourceHooks,
-		dynamicFactory:  dynamicFactory,
-		discoveryHelper: discoveryHelper,
-		blockStore:      blockStore,
+		backupRequest:         backupRequest,
+		backedUpItems:         backedUpItems,
+		tarWriter:             tarWriter,
+		dynamicFactory:        dynamicFactory,
+		discoveryHelper:       discoveryHelper,
+		resticBackupper:       resticBackupper,
+		resticSnapshotTracker: resticSnapshotTracker,
+		blockStoreGetter:      blockStoreGetter,
+
 		itemHookHandler: &defaultItemHookHandler{
 			podCommandExecutor: podCommandExecutor,
 		},
-		resticBackupper:       resticBackupper,
-		resticSnapshotTracker: resticSnapshotTracker,
 	}
 
 	// this is for testing purposes
@@ -105,21 +95,18 @@ type ItemBackupper interface {
 }
 
 type defaultItemBackupper struct {
-	backup                *api.Backup
-	namespaces            *collections.IncludesExcludes
-	resources             *collections.IncludesExcludes
+	backupRequest         *Request
 	backedUpItems         map[itemKey]struct{}
-	actions               []resolvedAction
 	tarWriter             tarWriter
-	resourceHooks         []resourceHook
 	dynamicFactory        client.DynamicFactory
 	discoveryHelper       discovery.Helper
-	blockStore            cloudprovider.BlockStore
 	resticBackupper       restic.Backupper
 	resticSnapshotTracker *pvcSnapshotTracker
+	blockStoreGetter      BlockStoreGetter
 
-	itemHookHandler         itemHookHandler
-	additionalItemBackupper ItemBackupper
+	itemHookHandler             itemHookHandler
+	additionalItemBackupper     ItemBackupper
+	snapshotLocationBlockStores map[string]cloudprovider.BlockStore
 }
 
 // backupItem backs up an individual item to tarWriter. The item may be excluded based on the
@@ -140,19 +127,19 @@ func (ib *defaultItemBackupper) backupItem(logger logrus.FieldLogger, obj runtim
 
 	// NOTE: we have to re-check namespace & resource includes/excludes because it's possible that
 	// backupItem can be invoked by a custom action.
-	if namespace != "" && !ib.namespaces.ShouldInclude(namespace) {
+	if namespace != "" && !ib.backupRequest.NamespaceIncludesExcludes.ShouldInclude(namespace) {
 		log.Info("Excluding item because namespace is excluded")
 		return nil
 	}
 
 	// NOTE: we specifically allow namespaces to be backed up even if IncludeClusterResources is
 	// false.
-	if namespace == "" && groupResource != kuberesource.Namespaces && ib.backup.Spec.IncludeClusterResources != nil && !*ib.backup.Spec.IncludeClusterResources {
+	if namespace == "" && groupResource != kuberesource.Namespaces && ib.backupRequest.Spec.IncludeClusterResources != nil && !*ib.backupRequest.Spec.IncludeClusterResources {
 		log.Info("Excluding item because resource is cluster-scoped and backup.spec.includeClusterResources is false")
 		return nil
 	}
 
-	if !ib.resources.ShouldInclude(groupResource.String()) {
+	if !ib.backupRequest.ResourceIncludesExcludes.ShouldInclude(groupResource.String()) {
 		log.Info("Excluding item because resource is excluded")
 		return nil
 	}
@@ -176,7 +163,7 @@ func (ib *defaultItemBackupper) backupItem(logger logrus.FieldLogger, obj runtim
 	log.Info("Backing up resource")
 
 	log.Debug("Executing pre hooks")
-	if err := ib.itemHookHandler.handleHooks(log, groupResource, obj, ib.resourceHooks, hookPhasePre); err != nil {
+	if err := ib.itemHookHandler.handleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hookPhasePre); err != nil {
 		return err
 	}
 
@@ -210,7 +197,7 @@ func (ib *defaultItemBackupper) backupItem(logger logrus.FieldLogger, obj runtim
 
 		// if there was an error running actions, execute post hooks and return
 		log.Debug("Executing post hooks")
-		if err := ib.itemHookHandler.handleHooks(log, groupResource, obj, ib.resourceHooks, hookPhasePost); err != nil {
+		if err := ib.itemHookHandler.handleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hookPhasePost); err != nil {
 			backupErrs = append(backupErrs, err)
 		}
 
@@ -222,9 +209,7 @@ func (ib *defaultItemBackupper) backupItem(logger logrus.FieldLogger, obj runtim
 	}
 
 	if groupResource == kuberesource.PersistentVolumes {
-		if ib.blockStore == nil {
-			log.Debug("Skipping Persistent Volume snapshot because they're not enabled.")
-		} else if err := ib.takePVSnapshot(obj, ib.backup, log); err != nil {
+		if err := ib.takePVSnapshot(obj, log); err != nil {
 			backupErrs = append(backupErrs, err)
 		}
 	}
@@ -243,7 +228,7 @@ func (ib *defaultItemBackupper) backupItem(logger logrus.FieldLogger, obj runtim
 	}
 
 	log.Debug("Executing post hooks")
-	if err := ib.itemHookHandler.handleHooks(log, groupResource, obj, ib.resourceHooks, hookPhasePost); err != nil {
+	if err := ib.itemHookHandler.handleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hookPhasePost); err != nil {
 		backupErrs = append(backupErrs, err)
 	}
 
@@ -294,7 +279,7 @@ func (ib *defaultItemBackupper) backupPodVolumes(log logrus.FieldLogger, pod *co
 		return nil, nil
 	}
 
-	return ib.resticBackupper.BackupPodVolumes(ib.backup, pod, log)
+	return ib.resticBackupper.BackupPodVolumes(ib.backupRequest.Backup, pod, log)
 }
 
 func (ib *defaultItemBackupper) executeActions(
@@ -304,7 +289,7 @@ func (ib *defaultItemBackupper) executeActions(
 	name, namespace string,
 	metadata metav1.Object,
 ) (runtime.Unstructured, error) {
-	for _, action := range ib.actions {
+	for _, action := range ib.backupRequest.ResolvedActions {
 		if !action.resourceIncludesExcludes.ShouldInclude(groupResource.String()) {
 			log.Debug("Skipping action because it does not apply to this resource")
 			continue
@@ -322,7 +307,7 @@ func (ib *defaultItemBackupper) executeActions(
 
 		log.Info("Executing custom action")
 
-		updatedItem, additionalItemIdentifiers, err := action.Execute(obj, ib.backup)
+		updatedItem, additionalItemIdentifiers, err := action.Execute(obj, ib.backupRequest.Backup)
 		if err != nil {
 			// We want this to show up in the log file at the place where the error occurs. When we return
 			// the error, it get aggregated with all the other ones at the end of the backup, making it
@@ -358,6 +343,30 @@ func (ib *defaultItemBackupper) executeActions(
 	return obj, nil
 }
 
+// blockStore instantiates and initializes a BlockStore given a VolumeSnapshotLocation,
+// or returns an existing one if one's already been initialized for the location.
+func (ib *defaultItemBackupper) blockStore(snapshotLocation *api.VolumeSnapshotLocation) (cloudprovider.BlockStore, error) {
+	if bs, ok := ib.snapshotLocationBlockStores[snapshotLocation.Name]; ok {
+		return bs, nil
+	}
+
+	bs, err := ib.blockStoreGetter.GetBlockStore(snapshotLocation.Spec.Provider)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := bs.Init(snapshotLocation.Spec.Config); err != nil {
+		return nil, err
+	}
+
+	if ib.snapshotLocationBlockStores == nil {
+		ib.snapshotLocationBlockStores = make(map[string]cloudprovider.BlockStore)
+	}
+	ib.snapshotLocationBlockStores[snapshotLocation.Name] = bs
+
+	return bs, nil
+}
+
 // zoneLabel is the label that stores availability-zone info
 // on PVs
 const zoneLabel = "failure-domain.beta.kubernetes.io/zone"
@@ -365,10 +374,10 @@ const zoneLabel = "failure-domain.beta.kubernetes.io/zone"
 // takePVSnapshot triggers a snapshot for the volume/disk underlying a PersistentVolume if the provided
 // backup has volume snapshots enabled and the PV is of a compatible type. Also records cloud
 // disk type and IOPS (if applicable) to be able to restore to current state later.
-func (ib *defaultItemBackupper) takePVSnapshot(obj runtime.Unstructured, backup *api.Backup, log logrus.FieldLogger) error {
+func (ib *defaultItemBackupper) takePVSnapshot(obj runtime.Unstructured, log logrus.FieldLogger) error {
 	log.Info("Executing takePVSnapshot")
 
-	if backup.Spec.SnapshotVolumes != nil && !*backup.Spec.SnapshotVolumes {
+	if ib.backupRequest.Spec.SnapshotVolumes != nil && !*ib.backupRequest.Spec.SnapshotVolumes {
 		log.Info("Backup has volume snapshots disabled; skipping volume snapshot action.")
 		return nil
 	}
@@ -402,11 +411,38 @@ func (ib *defaultItemBackupper) takePVSnapshot(obj runtime.Unstructured, backup 
 		log.Infof("label %q is not present on PersistentVolume", zoneLabel)
 	}
 
-	volumeID, err := ib.blockStore.GetVolumeID(obj)
-	if err != nil {
-		return errors.Wrapf(err, "error getting volume ID for PersistentVolume")
+	var (
+		volumeID   string
+		blockStore cloudprovider.BlockStore
+	)
+
+	for _, snapshotLocation := range ib.backupRequest.SnapshotLocations {
+		bs, err := ib.blockStore(snapshotLocation)
+		if err != nil {
+			log.WithError(err).WithField("volumeSnapshotLocation", snapshotLocation).Error("Error getting block store for volume snapshot location")
+			continue
+		}
+
+		log := log.WithFields(map[string]interface{}{
+			"volumeSnapshotLocation": snapshotLocation.Name,
+			"persistentVolume":       metadata.GetName(),
+		})
+
+		if volumeID, err = bs.GetVolumeID(obj); err != nil {
+			log.WithError(err).Errorf("Error attempting to get volume ID for persistent volume")
+			continue
+		}
+		if volumeID == "" {
+			log.Infof("No volume ID returned by block store for persistent volume")
+			continue
+		}
+
+		log.Infof("Got volume ID for persistent volume")
+		blockStore = bs
+		break
 	}
-	if volumeID == "" {
+
+	if blockStore == nil {
 		log.Info("PersistentVolume is not a supported volume type for snapshots, skipping.")
 		return nil
 	}
@@ -414,29 +450,29 @@ func (ib *defaultItemBackupper) takePVSnapshot(obj runtime.Unstructured, backup 
 	log = log.WithField("volumeID", volumeID)
 
 	tags := map[string]string{
-		"ark.heptio.com/backup": backup.Name,
+		"ark.heptio.com/backup": ib.backupRequest.Name,
 		"ark.heptio.com/pv":     metadata.GetName(),
 	}
 
 	log.Info("Snapshotting PersistentVolume")
-	snapshotID, err := ib.blockStore.CreateSnapshot(volumeID, pvFailureDomainZone, tags)
+	snapshotID, err := blockStore.CreateSnapshot(volumeID, pvFailureDomainZone, tags)
 	if err != nil {
 		// log+error on purpose - log goes to the per-backup log file, error goes to the backup
 		log.WithError(err).Error("error creating snapshot")
 		return errors.WithMessage(err, "error creating snapshot")
 	}
 
-	volumeType, iops, err := ib.blockStore.GetVolumeInfo(volumeID, pvFailureDomainZone)
+	volumeType, iops, err := blockStore.GetVolumeInfo(volumeID, pvFailureDomainZone)
 	if err != nil {
 		log.WithError(err).Error("error getting volume info")
 		return errors.WithMessage(err, "error getting volume info")
 	}
 
-	if backup.Status.VolumeBackups == nil {
-		backup.Status.VolumeBackups = make(map[string]*api.VolumeBackupInfo)
+	if ib.backupRequest.Status.VolumeBackups == nil {
+		ib.backupRequest.Status.VolumeBackups = make(map[string]*api.VolumeBackupInfo)
 	}
 
-	backup.Status.VolumeBackups[name] = &api.VolumeBackupInfo{
+	ib.backupRequest.Status.VolumeBackups[name] = &api.VolumeBackupInfo{
 		SnapshotID:       snapshotID,
 		Type:             volumeType,
 		Iops:             iops,

--- a/pkg/backup/request.go
+++ b/pkg/backup/request.go
@@ -1,0 +1,19 @@
+package backup
+
+import (
+	arkv1api "github.com/heptio/ark/pkg/apis/ark/v1"
+	"github.com/heptio/ark/pkg/util/collections"
+)
+
+// Request is a request for a backup, with all references to other objects
+// materialized (e.g. backup/snapshot locations, includes/excludes, etc.)
+type Request struct {
+	*arkv1api.Backup
+
+	StorageLocation           *arkv1api.BackupStorageLocation
+	SnapshotLocations         []*arkv1api.VolumeSnapshotLocation
+	NamespaceIncludesExcludes *collections.IncludesExcludes
+	ResourceIncludesExcludes  *collections.IncludesExcludes
+	ResourceHooks             []resourceHook
+	ResolvedActions           []resolvedAction
+}

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	api "github.com/heptio/ark/pkg/apis/ark/v1"
-	"github.com/heptio/ark/pkg/backup"
+	pkgbackup "github.com/heptio/ark/pkg/backup"
 	arkv1client "github.com/heptio/ark/pkg/generated/clientset/versioned/typed/ark/v1"
 	informers "github.com/heptio/ark/pkg/generated/informers/externalversions/ark/v1"
 	listers "github.com/heptio/ark/pkg/generated/listers/ark/v1"
@@ -55,8 +55,7 @@ const backupVersion = 1
 type backupController struct {
 	*genericController
 
-	backupper                backup.Backupper
-	pvProviderExists         bool
+	backupper                pkgbackup.Backupper
 	lister                   listers.BackupLister
 	client                   arkv1client.BackupsGetter
 	clock                    clock.Clock
@@ -66,7 +65,7 @@ type backupController struct {
 	backupLocationLister     listers.BackupStorageLocationLister
 	defaultBackupLocation    string
 	snapshotLocationLister   listers.VolumeSnapshotLocationLister
-	defaultSnapshotLocations map[string]string
+	defaultSnapshotLocations map[string]*api.VolumeSnapshotLocation
 	metrics                  *metrics.ServerMetrics
 	newBackupStore           func(*api.BackupStorageLocation, persistence.ObjectStoreGetter, logrus.FieldLogger) (persistence.BackupStore, error)
 }
@@ -74,8 +73,7 @@ type backupController struct {
 func NewBackupController(
 	backupInformer informers.BackupInformer,
 	client arkv1client.BackupsGetter,
-	backupper backup.Backupper,
-	pvProviderExists bool,
+	backupper pkgbackup.Backupper,
 	logger logrus.FieldLogger,
 	backupLogLevel logrus.Level,
 	newPluginManager func(logrus.FieldLogger) plugin.Manager,
@@ -83,13 +81,12 @@ func NewBackupController(
 	backupLocationInformer informers.BackupStorageLocationInformer,
 	defaultBackupLocation string,
 	volumeSnapshotLocationInformer informers.VolumeSnapshotLocationInformer,
-	defaultSnapshotLocations map[string]string,
+	defaultSnapshotLocations map[string]*api.VolumeSnapshotLocation,
 	metrics *metrics.ServerMetrics,
 ) Interface {
 	c := &backupController{
 		genericController:        newGenericController("backup", logger),
 		backupper:                backupper,
-		pvProviderExists:         pvProviderExists,
 		lister:                   backupInformer.Lister(),
 		client:                   client,
 		clock:                    &clock.RealClock{},
@@ -151,7 +148,7 @@ func (c *backupController) processBackup(key string) error {
 	}
 
 	log.Debug("Getting backup")
-	backup, err := c.lister.Backups(ns).Get(name)
+	original, err := c.lister.Backups(ns).Get(name)
 	if err != nil {
 		return errors.Wrap(err, "error getting backup")
 	}
@@ -164,68 +161,53 @@ func (c *backupController) processBackup(key string) error {
 	// informer sees the update. In the latter case, after the informer has seen the update to
 	// InProgress, we still need this check so we can return nil to indicate we've finished processing
 	// this key (even though it was a no-op).
-	switch backup.Status.Phase {
+	switch original.Status.Phase {
 	case "", api.BackupPhaseNew:
 		// only process new backups
 	default:
 		return nil
 	}
 
-	log.Debug("Cloning backup")
-	// store ref to original for creating patch
-	original := backup
-	// don't modify items in the cache
-	backup = backup.DeepCopy()
+	log.Debug("Preparing backup request")
+	request := c.prepareBackupRequest(original)
 
-	// set backup version
-	backup.Status.Version = backupVersion
-
-	// calculate expiration
-	if backup.Spec.TTL.Duration > 0 {
-		backup.Status.Expiration = metav1.NewTime(c.clock.Now().Add(backup.Spec.TTL.Duration))
-	}
-
-	backupLocation, errs := c.getLocationAndValidate(backup, c.defaultBackupLocation)
-	errs = append(errs, c.defaultAndValidateSnapshotLocations(backup, c.defaultSnapshotLocations)...)
-	backup.Status.ValidationErrors = append(backup.Status.ValidationErrors, errs...)
-
-	if len(backup.Status.ValidationErrors) > 0 {
-		backup.Status.Phase = api.BackupPhaseFailedValidation
+	if len(request.Status.ValidationErrors) > 0 {
+		request.Status.Phase = api.BackupPhaseFailedValidation
 	} else {
-		backup.Status.Phase = api.BackupPhaseInProgress
+		request.Status.Phase = api.BackupPhaseInProgress
 	}
 
 	// update status
-	updatedBackup, err := patchBackup(original, backup, c.client)
+	updatedBackup, err := patchBackup(original, request.Backup, c.client)
 	if err != nil {
-		return errors.Wrapf(err, "error updating Backup status to %s", backup.Status.Phase)
+		return errors.Wrapf(err, "error updating Backup status to %s", request.Status.Phase)
 	}
 	// store ref to just-updated item for creating patch
 	original = updatedBackup
-	backup = updatedBackup.DeepCopy()
+	request.Backup = updatedBackup.DeepCopy()
 
-	if backup.Status.Phase == api.BackupPhaseFailedValidation {
+	if request.Status.Phase == api.BackupPhaseFailedValidation {
 		return nil
 	}
 
-	c.backupTracker.Add(backup.Namespace, backup.Name)
-	defer c.backupTracker.Delete(backup.Namespace, backup.Name)
+	c.backupTracker.Add(request.Namespace, request.Name)
+	defer c.backupTracker.Delete(request.Namespace, request.Name)
 
 	log.Debug("Running backup")
 	// execution & upload of backup
-	backupScheduleName := backup.GetLabels()["ark-schedule"]
+	backupScheduleName := request.GetLabels()["ark-schedule"]
 	c.metrics.RegisterBackupAttempt(backupScheduleName)
 
-	if err := c.runBackup(backup, backupLocation); err != nil {
+	if err := c.runBackup(request); err != nil {
 		log.WithError(err).Error("backup failed")
-		backup.Status.Phase = api.BackupPhaseFailed
+		request.Status.Phase = api.BackupPhaseFailed
 		c.metrics.RegisterBackupFailed(backupScheduleName)
 	} else {
 		c.metrics.RegisterBackupSuccess(backupScheduleName)
 	}
 
 	log.Debug("Updating backup's final status")
-	if _, err := patchBackup(original, backup, c.client); err != nil {
+	if _, err := patchBackup(original, request.Backup, c.client); err != nil {
 		log.WithError(err).Error("error updating backup's final status")
 	}
 
@@ -256,84 +238,107 @@ func patchBackup(original, updated *api.Backup, client arkv1client.BackupsGetter
 	return res, nil
 }
 
-func (c *backupController) getLocationAndValidate(itm *api.Backup, defaultBackupLocation string) (*api.BackupStorageLocation, []string) {
-	var validationErrors []string
-
-	for _, err := range collections.ValidateIncludesExcludes(itm.Spec.IncludedResources, itm.Spec.ExcludedResources) {
-		validationErrors = append(validationErrors, fmt.Sprintf("Invalid included/excluded resource lists: %v", err))
+func (c *backupController) prepareBackupRequest(backup *api.Backup) *pkgbackup.Request {
+	request := &pkgbackup.Request{
+		Backup: backup.DeepCopy(), // don't modify items in the cache
 	}
 
-	for _, err := range collections.ValidateIncludesExcludes(itm.Spec.IncludedNamespaces, itm.Spec.ExcludedNamespaces) {
-		validationErrors = append(validationErrors, fmt.Sprintf("Invalid included/excluded namespace lists: %v", err))
+	// set backup version
+	request.Status.Version = backupVersion
+
+	// calculate expiration
+	if request.Spec.TTL.Duration > 0 {
+		request.Status.Expiration = metav1.NewTime(c.clock.Now().Add(request.Spec.TTL.Duration))
 	}
 
-	if itm.Spec.StorageLocation == "" {
-		itm.Spec.StorageLocation = defaultBackupLocation
+	// default storage location if not specified
+	if request.Spec.StorageLocation == "" {
+		request.Spec.StorageLocation = c.defaultBackupLocation
 	}
 
 	// add the storage location as a label for easy filtering later.
-	if itm.Labels == nil {
-		itm.Labels = make(map[string]string)
+	if request.Labels == nil {
+		request.Labels = make(map[string]string)
 	}
-	itm.Labels[api.StorageLocationLabel] = itm.Spec.StorageLocation
+	request.Labels[api.StorageLocationLabel] = request.Spec.StorageLocation
 
-	var backupLocation *api.BackupStorageLocation
-	backupLocation, err := c.backupLocationLister.BackupStorageLocations(itm.Namespace).Get(itm.Spec.StorageLocation)
-	if err != nil {
-		validationErrors = append(validationErrors, fmt.Sprintf("Error getting backup storage location: %v", err))
+	// validate the included/excluded resources and namespaces
+	for _, err := range collections.ValidateIncludesExcludes(request.Spec.IncludedResources, request.Spec.ExcludedResources) {
+		request.Status.ValidationErrors = append(request.Status.ValidationErrors, fmt.Sprintf("Invalid included/excluded resource lists: %v", err))
 	}
 
-	return backupLocation, validationErrors
+	for _, err := range collections.ValidateIncludesExcludes(request.Spec.IncludedNamespaces, request.Spec.ExcludedNamespaces) {
+		request.Status.ValidationErrors = append(request.Status.ValidationErrors, fmt.Sprintf("Invalid included/excluded namespace lists: %v", err))
+	}
+
+	// validate the storage location, and store the BackupStorageLocation API obj on the request
+	if storageLocation, err := c.backupLocationLister.BackupStorageLocations(request.Namespace).Get(request.Spec.StorageLocation); err != nil {
+		request.Status.ValidationErrors = append(request.Status.ValidationErrors, fmt.Sprintf("Error getting backup storage location: %v", err))
+	} else {
+		request.StorageLocation = storageLocation
+	}
+
+	// validate and get the backup's VolumeSnapshotLocations, and store the
+	// VolumeSnapshotLocation API objs on the request
+	if locs, errs := c.validateAndGetSnapshotLocations(request.Backup); len(errs) > 0 {
+		request.Status.ValidationErrors = append(request.Status.ValidationErrors, errs...)
+	} else {
+		request.Spec.VolumeSnapshotLocations = nil
+		for _, loc := range locs {
+			request.Spec.VolumeSnapshotLocations = append(request.Spec.VolumeSnapshotLocations, loc.Name)
+			request.SnapshotLocations = append(request.SnapshotLocations, loc)
+		}
+	}
+
+	return request
 }
 
-// defaultAndValidateSnapshotLocations ensures:
-// - each location name in Spec VolumeSnapshotLocation exists as a location
-// - exactly 1 location per existing or default provider
-// - a given default provider's location name is added to the Spec VolumeSnapshotLocation if it does not exist as a VSL
-func (c *backupController) defaultAndValidateSnapshotLocations(itm *api.Backup, defaultLocations map[string]string) []string {
-	var errors []string
-	perProviderLocationName := make(map[string]string)
-	var finalLocationNameList []string
-	for _, locationName := range itm.Spec.VolumeSnapshotLocations {
+// validateAndGetSnapshotLocations gets a collection of VolumeSnapshotLocation objects that
+// this backup will use (returned as a map of provider name -> VSL), and ensures:
+// - each location name in .spec.volumeSnapshotLocations exists as a location
+// - exactly 1 location per provider
+// - a given provider's default location name is added to .spec.volumeSnapshotLocations if one
+//   is not explicitly specified for the provider
+func (c *backupController) validateAndGetSnapshotLocations(backup *api.Backup) (map[string]*api.VolumeSnapshotLocation, []string) {
+	errors := []string{}
+	providerLocations := make(map[string]*api.VolumeSnapshotLocation)
+
+	for _, locationName := range backup.Spec.VolumeSnapshotLocations {
 		// validate each locationName exists as a VolumeSnapshotLocation
-		location, err := c.snapshotLocationLister.VolumeSnapshotLocations(itm.Namespace).Get(locationName)
+		location, err := c.snapshotLocationLister.VolumeSnapshotLocations(backup.Namespace).Get(locationName)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("error getting volume snapshot location named %s: %v", locationName, err))
 			continue
 		}
 
-		// ensure we end up with exactly 1 locationName *per provider*
-		providerLocationName := perProviderLocationName[location.Spec.Provider]
-		if providerLocationName != "" {
+		// ensure we end up with exactly 1 location *per provider*
+		if providerLocation, ok := providerLocations[location.Spec.Provider]; ok {
 			// if > 1 location name per provider as in ["aws-us-east-1" | "aws-us-west-1"] (same provider, multiple names)
-			if providerLocationName != locationName {
-				errors = append(errors, fmt.Sprintf("more than one VolumeSnapshotLocation name specified for provider %s: %s; unexpected name was %s", location.Spec.Provider, locationName, providerLocationName))
+			if providerLocation.Name != locationName {
+				errors = append(errors, fmt.Sprintf("more than one VolumeSnapshotLocation name specified for provider %s: %s; unexpected name was %s", location.Spec.Provider, locationName, providerLocation.Name))
 				continue
 			}
 		} else {
-			// no dup exists: add locationName to the final list
-			finalLocationNameList = append(finalLocationNameList, locationName)
 			// keep track of all valid existing locations, per provider
-			perProviderLocationName[location.Spec.Provider] = locationName
+			providerLocations[location.Spec.Provider] = location
 		}
 	}
 
 	if len(errors) > 0 {
-		return errors
+		return nil, errors
 	}
 
-	for provider, defaultLocationName := range defaultLocations {
+	for provider, defaultLocation := range c.defaultSnapshotLocations {
 		// if a location name for a given provider does not already exist, add the provider's default
-		if _, ok := perProviderLocationName[provider]; !ok {
-			finalLocationNameList = append(finalLocationNameList, defaultLocationName)
+		if _, ok := providerLocations[provider]; !ok {
+			providerLocations[provider] = defaultLocation
 		}
 	}
-	itm.Spec.VolumeSnapshotLocations = finalLocationNameList
 
-	return nil
+	return providerLocations, nil
 }
 
-func (c *backupController) runBackup(backup *api.Backup, backupLocation *api.BackupStorageLocation) error {
+func (c *backupController) runBackup(backup *pkgbackup.Request) error {
 	log := c.logger.WithField("backup", kubeutil.NamespaceAndName(backup))
 	log.Info("Starting backup")
 	backup.Status.StartTimestamp.Time = c.clock.Now()
@@ -370,17 +375,15 @@ func (c *backupController) runBackup(backup *api.Backup, backupLocation *api.Bac
 		return err
 	}
 
-	backupStore, err := c.newBackupStore(backupLocation, pluginManager, log)
+	backupStore, err := c.newBackupStore(backup.StorageLocation, pluginManager, log)
 	if err != nil {
 		return err
 	}
 
 	var errs []error
 
-	var backupJSONToUpload, backupFileToUpload io.Reader
-
 	// Do the actual backup
-	if err := c.backupper.Backup(log, backup, backupFile, actions); err != nil {
+	if err := c.backupper.Backup(log, backup, backupFile, actions, pluginManager); err != nil {
 		errs = append(errs, err)
 
 		backup.Status.Phase = api.BackupPhaseFailed
@@ -392,8 +395,9 @@ func (c *backupController) runBackup(backup *api.Backup, backupLocation *api.Bac
 	// Otherwise, the JSON file in object storage has a CompletionTimestamp of 'null'.
 	backup.Status.CompletionTimestamp.Time = c.clock.Now()
 
+	var backupJSONToUpload, backupFileToUpload io.Reader
 	backupJSON := new(bytes.Buffer)
-	if err := encode.EncodeTo(backup, "json", backupJSON); err != nil {
+	if err := encode.EncodeTo(backup.Backup, "json", backupJSON); err != nil {
 		errs = append(errs, errors.Wrap(err, "error encoding backup"))
 	} else {
 		// Only upload the json and backup tarball if encoding to json succeeded.

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -18,24 +18,24 @@ package controller
 
 import (
 	"bytes"
-	"encoding/json"
+	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/clock"
-	core "k8s.io/client-go/testing"
 
 	"github.com/heptio/ark/pkg/apis/ark/v1"
-	"github.com/heptio/ark/pkg/backup"
+	pkgbackup "github.com/heptio/ark/pkg/backup"
 	"github.com/heptio/ark/pkg/generated/clientset/versioned/fake"
 	informers "github.com/heptio/ark/pkg/generated/informers/externalversions"
 	"github.com/heptio/ark/pkg/metrics"
@@ -43,7 +43,6 @@ import (
 	persistencemocks "github.com/heptio/ark/pkg/persistence/mocks"
 	"github.com/heptio/ark/pkg/plugin"
 	pluginmocks "github.com/heptio/ark/pkg/plugin/mocks"
-	"github.com/heptio/ark/pkg/util/collections"
 	"github.com/heptio/ark/pkg/util/logging"
 	arktest "github.com/heptio/ark/pkg/util/test"
 )
@@ -52,384 +51,313 @@ type fakeBackupper struct {
 	mock.Mock
 }
 
-func (b *fakeBackupper) Backup(logger logrus.FieldLogger, backup *v1.Backup, backupFile io.Writer, actions []backup.ItemAction) error {
-	args := b.Called(logger, backup, backupFile, actions)
+func (b *fakeBackupper) Backup(logger logrus.FieldLogger, backup *pkgbackup.Request, backupFile io.Writer, actions []pkgbackup.ItemAction, blockStoreGetter pkgbackup.BlockStoreGetter) error {
+	args := b.Called(logger, backup, backupFile, actions, blockStoreGetter)
 	return args.Error(0)
 }
 
-func TestProcessBackup(t *testing.T) {
+func TestProcessBackupNonProcessedItems(t *testing.T) {
 	tests := []struct {
-		name             string
-		key              string
-		expectError      bool
-		expectedIncludes []string
-		expectedExcludes []string
-		backup           *arktest.TestBackup
-		expectBackup     bool
-		allowSnapshots   bool
-		defaultLocations map[string]string
+		name        string
+		key         string
+		backup      *v1.Backup
+		expectedErr string
 	}{
 		{
-			name:        "bad key",
+			name:        "bad key returns error",
 			key:         "bad/key/here",
-			expectError: true,
+			expectedErr: "error splitting queue key: unexpected key format: \"bad/key/here\"",
 		},
 		{
-			name:        "lister failed",
-			key:         "heptio-ark/backup1",
-			expectError: true,
+			name:        "backup not found in lister returns error",
+			key:         "nonexistent/backup",
+			expectedErr: "error getting backup: backup.ark.heptio.com \"backup\" not found",
 		},
 		{
-			name:         "do not process phase FailedValidation",
-			key:          "heptio-ark/backup1",
-			backup:       arktest.NewTestBackup().WithName("backup1").WithPhase(v1.BackupPhaseFailedValidation),
-			expectBackup: false,
+			name:   "FailedValidation backup is not processed",
+			key:    "heptio-ark/backup-1",
+			backup: arktest.NewTestBackup().WithName("backup-1").WithPhase(v1.BackupPhaseFailedValidation).Backup,
 		},
 		{
-			name:         "do not process phase InProgress",
-			key:          "heptio-ark/backup1",
-			backup:       arktest.NewTestBackup().WithName("backup1").WithPhase(v1.BackupPhaseInProgress),
-			expectBackup: false,
+			name:   "InProgress backup is not processed",
+			key:    "heptio-ark/backup-1",
+			backup: arktest.NewTestBackup().WithName("backup-1").WithPhase(v1.BackupPhaseInProgress).Backup,
 		},
 		{
-			name:         "do not process phase Completed",
-			key:          "heptio-ark/backup1",
-			backup:       arktest.NewTestBackup().WithName("backup1").WithPhase(v1.BackupPhaseCompleted),
-			expectBackup: false,
+			name:   "Completed backup is not processed",
+			key:    "heptio-ark/backup-1",
+			backup: arktest.NewTestBackup().WithName("backup-1").WithPhase(v1.BackupPhaseCompleted).Backup,
 		},
 		{
-			name:         "do not process phase Failed",
-			key:          "heptio-ark/backup1",
-			backup:       arktest.NewTestBackup().WithName("backup1").WithPhase(v1.BackupPhaseFailed),
-			expectBackup: false,
-		},
-		{
-			name:         "do not process phase other",
-			key:          "heptio-ark/backup1",
-			backup:       arktest.NewTestBackup().WithName("backup1").WithPhase("arg"),
-			expectBackup: false,
-		},
-		{
-			name:         "invalid included/excluded resources fails validation",
-			key:          "heptio-ark/backup1",
-			backup:       arktest.NewTestBackup().WithName("backup1").WithPhase(v1.BackupPhaseNew).WithIncludedResources("foo").WithExcludedResources("foo"),
-			expectBackup: false,
-		},
-		{
-			name:         "invalid included/excluded namespaces fails validation",
-			key:          "heptio-ark/backup1",
-			backup:       arktest.NewTestBackup().WithName("backup1").WithPhase(v1.BackupPhaseNew).WithIncludedNamespaces("foo").WithExcludedNamespaces("foo"),
-			expectBackup: false,
-		},
-		{
-			name:             "make sure specified included and excluded resources are honored",
-			key:              "heptio-ark/backup1",
-			backup:           arktest.NewTestBackup().WithName("backup1").WithPhase(v1.BackupPhaseNew).WithIncludedResources("i", "j").WithExcludedResources("k", "l"),
-			expectedIncludes: []string{"i", "j"},
-			expectedExcludes: []string{"k", "l"},
-			expectBackup:     true,
-		},
-		{
-			name:         "if includednamespaces are specified, don't default to *",
-			key:          "heptio-ark/backup1",
-			backup:       arktest.NewTestBackup().WithName("backup1").WithPhase(v1.BackupPhaseNew).WithIncludedNamespaces("ns-1"),
-			expectBackup: true,
-		},
-		{
-			name:         "ttl",
-			key:          "heptio-ark/backup1",
-			backup:       arktest.NewTestBackup().WithName("backup1").WithPhase(v1.BackupPhaseNew).WithTTL(10 * time.Minute),
-			expectBackup: true,
-		},
-		{
-			name:         "backup with SnapshotVolumes when allowSnapshots=false fails validation",
-			key:          "heptio-ark/backup1",
-			backup:       arktest.NewTestBackup().WithName("backup1").WithPhase(v1.BackupPhaseNew).WithSnapshotVolumes(true),
-			expectBackup: false,
-		},
-		{
-			name:           "backup with SnapshotVolumes when allowSnapshots=true gets executed",
-			key:            "heptio-ark/backup1",
-			backup:         arktest.NewTestBackup().WithName("backup1").WithPhase(v1.BackupPhaseNew).WithSnapshotVolumes(true),
-			allowSnapshots: true,
-			expectBackup:   true,
-		},
-		{
-			name:         "Backup without a location will have it set to the default",
-			key:          "heptio-ark/backup1",
-			backup:       arktest.NewTestBackup().WithName("backup1").WithPhase(v1.BackupPhaseNew),
-			expectBackup: true,
-		},
-		{
-			name:         "Backup with a location completes",
-			key:          "heptio-ark/backup1",
-			backup:       arktest.NewTestBackup().WithName("backup1").WithPhase(v1.BackupPhaseNew).WithStorageLocation("loc1"),
-			expectBackup: true,
-		},
-		{
-			name:         "Backup with non-existent location will fail validation",
-			key:          "heptio-ark/backup1",
-			backup:       arktest.NewTestBackup().WithName("backup1").WithPhase(v1.BackupPhaseNew).WithStorageLocation("loc2"),
-			expectBackup: false,
+			name:   "Failed backup is not processed",
+			key:    "heptio-ark/backup-1",
+			backup: arktest.NewTestBackup().WithName("backup-1").WithPhase(v1.BackupPhaseFailed).Backup,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var (
-				client          = fake.NewSimpleClientset()
-				backupper       = &fakeBackupper{}
-				sharedInformers = informers.NewSharedInformerFactory(client, 0)
+				sharedInformers = informers.NewSharedInformerFactory(fake.NewSimpleClientset(), 0)
 				logger          = logging.DefaultLogger(logrus.DebugLevel)
-				clockTime, _    = time.Parse("Mon Jan 2 15:04:05 2006", "Mon Jan 2 15:04:05 2006")
-				pluginManager   = &pluginmocks.Manager{}
-				backupStore     = &persistencemocks.BackupStore{}
 			)
-			defer backupper.AssertExpectations(t)
-			defer pluginManager.AssertExpectations(t)
-			defer backupStore.AssertExpectations(t)
 
-			c := NewBackupController(
-				sharedInformers.Ark().V1().Backups(),
-				client.ArkV1(),
-				backupper,
-				test.allowSnapshots,
-				logger,
-				logrus.InfoLevel,
-				func(logrus.FieldLogger) plugin.Manager { return pluginManager },
-				NewBackupTracker(),
-				sharedInformers.Ark().V1().BackupStorageLocations(),
-				"default",
-				sharedInformers.Ark().V1().VolumeSnapshotLocations(),
-				test.defaultLocations,
-				metrics.NewServerMetrics(),
-			).(*backupController)
-
-			c.clock = clock.NewFakeClock(clockTime)
-
-			c.newBackupStore = func(*v1.BackupStorageLocation, persistence.ObjectStoreGetter, logrus.FieldLogger) (persistence.BackupStore, error) {
-				return backupStore, nil
+			c := &backupController{
+				genericController: newGenericController("backup-test", logger),
+				lister:            sharedInformers.Ark().V1().Backups().Lister(),
 			}
-
-			var expiration, startTime time.Time
 
 			if test.backup != nil {
-				// add directly to the informer's store so the lister can function and so we don't have to
-				// start the shared informers.
-				sharedInformers.Ark().V1().Backups().Informer().GetStore().Add(test.backup.Backup)
-
-				startTime = c.clock.Now()
-
-				if test.backup.Spec.TTL.Duration > 0 {
-					expiration = c.clock.Now().Add(test.backup.Spec.TTL.Duration)
-				}
+				require.NoError(t, sharedInformers.Ark().V1().Backups().Informer().GetStore().Add(test.backup))
 			}
 
-			if test.expectBackup {
-				// set up a Backup object to represent what we expect to be passed to backupper.Backup()
-				backup := test.backup.DeepCopy()
-				backup.Spec.IncludedResources = test.expectedIncludes
-				backup.Spec.ExcludedResources = test.expectedExcludes
-				backup.Spec.IncludedNamespaces = test.backup.Spec.IncludedNamespaces
-				backup.Spec.SnapshotVolumes = test.backup.Spec.SnapshotVolumes
-				backup.Status.Phase = v1.BackupPhaseInProgress
-				backup.Status.Expiration.Time = expiration
-				backup.Status.StartTimestamp.Time = startTime
-				backup.Status.Version = 1
-				backupper.On("Backup",
-					mock.Anything, // logger
-					backup,
-					mock.Anything, // backup file
-					mock.Anything, // actions
-				).Return(nil)
-
-				defaultLocation := &v1.BackupStorageLocation{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: backup.Namespace,
-						Name:      "default",
-					},
-					Spec: v1.BackupStorageLocationSpec{
-						Provider: "myCloud",
-						StorageType: v1.StorageType{
-							ObjectStorage: &v1.ObjectStorageLocation{
-								Bucket: "bucket",
-							},
-						},
-					},
-				}
-				loc1 := &v1.BackupStorageLocation{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: backup.Namespace,
-						Name:      "loc1",
-					},
-					Spec: v1.BackupStorageLocationSpec{
-						Provider: "myCloud",
-						StorageType: v1.StorageType{
-							ObjectStorage: &v1.ObjectStorageLocation{
-								Bucket: "bucket",
-							},
-						},
-					},
-				}
-				require.NoError(t, sharedInformers.Ark().V1().BackupStorageLocations().Informer().GetStore().Add(defaultLocation))
-				require.NoError(t, sharedInformers.Ark().V1().BackupStorageLocations().Informer().GetStore().Add(loc1))
-
-				pluginManager.On("GetBackupItemActions").Return(nil, nil)
-
-				// Ensure we have a CompletionTimestamp when uploading.
-				// Failures will display the bytes in buf.
-				completionTimestampIsPresent := func(buf *bytes.Buffer) bool {
-					json := buf.String()
-					timeString := `"completionTimestamp": "2006-01-02T15:04:05Z"`
-
-					return strings.Contains(json, timeString)
-				}
-				backupStore.On("PutBackup", test.backup.Name, mock.MatchedBy(completionTimestampIsPresent), mock.Anything, mock.Anything).Return(nil)
-				pluginManager.On("CleanupClients").Return()
-			}
-
-			// this is necessary so the Patch() call returns the appropriate object
-			client.PrependReactor("patch", "backups", func(action core.Action) (bool, runtime.Object, error) {
-				if test.backup == nil {
-					return true, nil, nil
-				}
-
-				patch := action.(core.PatchAction).GetPatch()
-				patchMap := make(map[string]interface{})
-
-				if err := json.Unmarshal(patch, &patchMap); err != nil {
-					t.Logf("error unmarshalling patch: %s\n", err)
-					return false, nil, err
-				}
-
-				phase, err := collections.GetString(patchMap, "status.phase")
-				if err != nil {
-					t.Logf("error getting status.phase: %s\n", err)
-					return false, nil, err
-				}
-
-				res := test.backup.DeepCopy()
-
-				// these are the fields that we expect to be set by
-				// the controller
-				res.Status.Version = 1
-				res.Status.Expiration.Time = expiration
-				res.Status.Phase = v1.BackupPhase(phase)
-
-				// If there's an error, it's mostly likely that the key wasn't found
-				// which is fine since not all patches will have them.
-				completionString, err := collections.GetString(patchMap, "status.completionTimestamp")
-				if err == nil {
-					completionTime, err := time.Parse(time.RFC3339Nano, completionString)
-					require.NoError(t, err, "unexpected completionTimestamp parsing error %v", err)
-					res.Status.CompletionTimestamp.Time = completionTime
-				}
-				startString, err := collections.GetString(patchMap, "status.startTimestamp")
-				if err == nil {
-					startTime, err := time.Parse(time.RFC3339Nano, startString)
-					require.NoError(t, err, "unexpected startTimestamp parsing error %v", err)
-					res.Status.StartTimestamp.Time = startTime
-				}
-
-				return true, res, nil
-			})
-
-			// method under test
 			err := c.processBackup(test.key)
-
-			if test.expectError {
-				require.Error(t, err, "processBackup should error")
-				return
-			}
-			require.NoError(t, err, "processBackup unexpected error: %v", err)
-
-			if !test.expectBackup {
-				// the AssertExpectations calls above make sure we aren't running anything we shouldn't be
-				return
-			}
-
-			actions := client.Actions()
-			require.Equal(t, 2, len(actions))
-
-			// structs and func for decoding patch content
-			type StatusPatch struct {
-				Expiration          time.Time      `json:"expiration"`
-				Version             int            `json:"version"`
-				Phase               v1.BackupPhase `json:"phase"`
-				StartTimestamp      metav1.Time    `json:"startTimestamp"`
-				CompletionTimestamp metav1.Time    `json:"completionTimestamp"`
-			}
-			type SpecPatch struct {
-				StorageLocation string `json:"storageLocation"`
-			}
-			type ObjectMetaPatch struct {
-				Labels map[string]string `json:"labels"`
-			}
-
-			type Patch struct {
-				Status     StatusPatch     `json:"status"`
-				Spec       SpecPatch       `json:"spec,omitempty"`
-				ObjectMeta ObjectMetaPatch `json:"metadata,omitempty"`
-			}
-
-			decode := func(decoder *json.Decoder) (interface{}, error) {
-				actual := new(Patch)
-				err := decoder.Decode(actual)
-
-				return *actual, err
-			}
-
-			// validate Patch call 1 (setting version, expiration, phase, and storage location)
-			var expected Patch
-			if test.backup.Spec.StorageLocation == "" {
-				expected = Patch{
-					Status: StatusPatch{
-						Version:    1,
-						Phase:      v1.BackupPhaseInProgress,
-						Expiration: expiration,
-					},
-					Spec: SpecPatch{
-						StorageLocation: "default",
-					},
-					ObjectMeta: ObjectMetaPatch{
-						Labels: map[string]string{
-							v1.StorageLocationLabel: "default",
-						},
-					},
-				}
+			if test.expectedErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, test.expectedErr, err.Error())
 			} else {
-				expected = Patch{
-					Status: StatusPatch{
-						Version:    1,
-						Phase:      v1.BackupPhaseInProgress,
-						Expiration: expiration,
-					},
-					ObjectMeta: ObjectMetaPatch{
-						Labels: map[string]string{
-							v1.StorageLocationLabel: test.backup.Spec.StorageLocation,
-						},
-					},
-				}
+				assert.Nil(t, err)
 			}
 
-			arktest.ValidatePatch(t, actions[0], expected, decode)
-
-			// validate Patch call 2 (setting phase, startTimestamp, completionTimestamp)
-			expected = Patch{
-				Status: StatusPatch{
-					Phase:               v1.BackupPhaseCompleted,
-					StartTimestamp:      metav1.Time{Time: c.clock.Now()},
-					CompletionTimestamp: metav1.Time{Time: c.clock.Now()},
-				},
-			}
-			arktest.ValidatePatch(t, actions[1], expected, decode)
+			// Any backup that would actually proceed to validation will cause a segfault because this
+			// test hasn't set up the necessary controller dependencies for validation/etc. So the lack
+			// of segfaults during test execution here imply that backups are not being processed, which
+			// is what we expect.
 		})
 	}
 }
 
-func TestDefaultAndValidateSnapshotLocations(t *testing.T) {
-	defaultLocationsAWS := map[string]string{"aws": "aws-us-east-2"}
-	defaultLocationsFake := map[string]string{"fake-provider": "some-name"}
+func TestProcessBackupValidationFailures(t *testing.T) {
+	defaultBackupLocation := arktest.NewTestBackupStorageLocation().WithName("loc-1").BackupStorageLocation
+
+	tests := []struct {
+		name           string
+		backup         *v1.Backup
+		backupLocation *v1.BackupStorageLocation
+		expectedErrs   []string
+	}{
+		{
+			name:           "invalid included/excluded resources fails validation",
+			backup:         arktest.NewTestBackup().WithName("backup-1").WithIncludedResources("foo").WithExcludedResources("foo").Backup,
+			backupLocation: defaultBackupLocation,
+			expectedErrs:   []string{"Invalid included/excluded resource lists: excludes list cannot contain an item in the includes list: foo"},
+		},
+		{
+			name:           "invalid included/excluded namespaces fails validation",
+			backup:         arktest.NewTestBackup().WithName("backup-1").WithIncludedNamespaces("foo").WithExcludedNamespaces("foo").Backup,
+			backupLocation: defaultBackupLocation,
+			expectedErrs:   []string{"Invalid included/excluded namespace lists: excludes list cannot contain an item in the includes list: foo"},
+		},
+		{
+			name:         "non-existent backup location fails validation",
+			backup:       arktest.NewTestBackup().WithName("backup-1").WithStorageLocation("nonexistent").Backup,
+			expectedErrs: []string{"Error getting backup storage location: backupstoragelocation.ark.heptio.com \"nonexistent\" not found"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var (
+				clientset       = fake.NewSimpleClientset(test.backup)
+				sharedInformers = informers.NewSharedInformerFactory(clientset, 0)
+				logger          = logging.DefaultLogger(logrus.DebugLevel)
+			)
+
+			c := &backupController{
+				genericController:     newGenericController("backup-test", logger),
+				client:                clientset.ArkV1(),
+				lister:                sharedInformers.Ark().V1().Backups().Lister(),
+				backupLocationLister:  sharedInformers.Ark().V1().BackupStorageLocations().Lister(),
+				defaultBackupLocation: defaultBackupLocation.Name,
+			}
+
+			require.NotNil(t, test.backup)
+			require.NoError(t, sharedInformers.Ark().V1().Backups().Informer().GetStore().Add(test.backup))
+
+			if test.backupLocation != nil {
+				_, err := clientset.ArkV1().BackupStorageLocations(test.backupLocation.Namespace).Create(test.backupLocation)
+				require.NoError(t, err)
+
+				require.NoError(t, sharedInformers.Ark().V1().BackupStorageLocations().Informer().GetStore().Add(test.backupLocation))
+			}
+
+			require.NoError(t, c.processBackup(fmt.Sprintf("%s/%s", test.backup.Namespace, test.backup.Name)))
+
+			res, err := clientset.ArkV1().Backups(test.backup.Namespace).Get(test.backup.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+
+			assert.Equal(t, v1.BackupPhaseFailedValidation, res.Status.Phase)
+			assert.Equal(t, test.expectedErrs, res.Status.ValidationErrors)
+
+			// Any backup that would actually proceed to processing will cause a segfault because this
+			// test hasn't set up the necessary controller dependencies for running backups. So the lack
+			// of segfaults during test execution here imply that backups are not being processed, which
+			// is what we expect.
+		})
+	}
+}
+
+func TestProcessBackupCompletions(t *testing.T) {
+	defaultBackupLocation := arktest.NewTestBackupStorageLocation().WithName("loc-1").BackupStorageLocation
+
+	now, err := time.Parse(time.RFC1123Z, time.RFC1123Z)
+	require.NoError(t, err)
+	now = now.Local()
+
+	tests := []struct {
+		name           string
+		backup         *v1.Backup
+		backupLocation *v1.BackupStorageLocation
+		expectedResult *v1.Backup
+	}{
+		{
+			name:           "backup with no backup location gets the default",
+			backup:         arktest.NewTestBackup().WithName("backup-1").Backup,
+			backupLocation: defaultBackupLocation,
+			expectedResult: &v1.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: v1.DefaultNamespace,
+					Name:      "backup-1",
+					Labels: map[string]string{
+						"ark.heptio.com/storage-location": "loc-1",
+					},
+				},
+				Spec: v1.BackupSpec{
+					StorageLocation: defaultBackupLocation.Name,
+				},
+				Status: v1.BackupStatus{
+					Phase:               v1.BackupPhaseCompleted,
+					Version:             1,
+					StartTimestamp:      metav1.NewTime(now),
+					CompletionTimestamp: metav1.NewTime(now),
+				},
+			},
+		},
+		{
+			name:           "backup with a specific backup location keeps it",
+			backup:         arktest.NewTestBackup().WithName("backup-1").WithStorageLocation("alt-loc").Backup,
+			backupLocation: arktest.NewTestBackupStorageLocation().WithName("alt-loc").BackupStorageLocation,
+			expectedResult: &v1.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: v1.DefaultNamespace,
+					Name:      "backup-1",
+					Labels: map[string]string{
+						"ark.heptio.com/storage-location": "alt-loc",
+					},
+				},
+				Spec: v1.BackupSpec{
+					StorageLocation: "alt-loc",
+				},
+				Status: v1.BackupStatus{
+					Phase:               v1.BackupPhaseCompleted,
+					Version:             1,
+					StartTimestamp:      metav1.NewTime(now),
+					CompletionTimestamp: metav1.NewTime(now),
+				},
+			},
+		},
+		{
+			name:           "backup with a TTL has expiration set",
+			backup:         arktest.NewTestBackup().WithName("backup-1").WithTTL(10 * time.Minute).Backup,
+			backupLocation: defaultBackupLocation,
+			expectedResult: &v1.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: v1.DefaultNamespace,
+					Name:      "backup-1",
+					Labels: map[string]string{
+						"ark.heptio.com/storage-location": "loc-1",
+					},
+				},
+				Spec: v1.BackupSpec{
+					TTL:             metav1.Duration{Duration: 10 * time.Minute},
+					StorageLocation: defaultBackupLocation.Name,
+				},
+				Status: v1.BackupStatus{
+					Phase:               v1.BackupPhaseCompleted,
+					Version:             1,
+					Expiration:          metav1.NewTime(now.Add(10 * time.Minute)),
+					StartTimestamp:      metav1.NewTime(now),
+					CompletionTimestamp: metav1.NewTime(now),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var (
+				clientset       = fake.NewSimpleClientset(test.backup)
+				sharedInformers = informers.NewSharedInformerFactory(clientset, 0)
+				logger          = logging.DefaultLogger(logrus.DebugLevel)
+				pluginManager   = new(pluginmocks.Manager)
+				backupStore     = new(persistencemocks.BackupStore)
+				backupper       = new(fakeBackupper)
+			)
+
+			c := &backupController{
+				genericController:     newGenericController("backup-test", logger),
+				client:                clientset.ArkV1(),
+				lister:                sharedInformers.Ark().V1().Backups().Lister(),
+				backupLocationLister:  sharedInformers.Ark().V1().BackupStorageLocations().Lister(),
+				defaultBackupLocation: defaultBackupLocation.Name,
+				backupTracker:         NewBackupTracker(),
+				metrics:               metrics.NewServerMetrics(),
+				clock:                 clock.NewFakeClock(now),
+				newPluginManager:      func(logrus.FieldLogger) plugin.Manager { return pluginManager },
+				newBackupStore: func(*v1.BackupStorageLocation, persistence.ObjectStoreGetter, logrus.FieldLogger) (persistence.BackupStore, error) {
+					return backupStore, nil
+				},
+				backupper: backupper,
+			}
+
+			pluginManager.On("GetBackupItemActions").Return(nil, nil)
+			pluginManager.On("CleanupClients").Return(nil)
+
+			backupper.On("Backup", mock.Anything, mock.Anything, mock.Anything, []pkgbackup.ItemAction(nil), pluginManager).Return(nil)
+
+			// Ensure we have a CompletionTimestamp when uploading.
+			// Failures will display the bytes in buf.
+			completionTimestampIsPresent := func(buf *bytes.Buffer) bool {
+				return strings.Contains(buf.String(), `"completionTimestamp": "2006-01-02T22:04:05Z"`)
+			}
+			backupStore.On("PutBackup", test.backup.Name, mock.MatchedBy(completionTimestampIsPresent), mock.Anything, mock.Anything).Return(nil)
+
+			// add the test's backup to the informer/lister store
+			require.NotNil(t, test.backup)
+			require.NoError(t, sharedInformers.Ark().V1().Backups().Informer().GetStore().Add(test.backup))
+
+			// add the default backup storage location to the clientset and the informer/lister store
+			_, err := clientset.ArkV1().BackupStorageLocations(defaultBackupLocation.Namespace).Create(defaultBackupLocation)
+			require.NoError(t, err)
+
+			require.NoError(t, sharedInformers.Ark().V1().BackupStorageLocations().Informer().GetStore().Add(defaultBackupLocation))
+
+			// add the test's backup storage location to the clientset and the informer/lister store
+			// if it's different than the default
+			if test.backupLocation != nil && test.backupLocation != defaultBackupLocation {
+				_, err := clientset.ArkV1().BackupStorageLocations(test.backupLocation.Namespace).Create(test.backupLocation)
+				require.NoError(t, err)
+
+				require.NoError(t, sharedInformers.Ark().V1().BackupStorageLocations().Informer().GetStore().Add(test.backupLocation))
+			}
+
+			require.NoError(t, c.processBackup(fmt.Sprintf("%s/%s", test.backup.Namespace, test.backup.Name)))
+
+			res, err := clientset.ArkV1().Backups(test.backup.Namespace).Get(test.backup.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expectedResult, res)
+		})
+	}
+}
+
+func TestValidateAndGetSnapshotLocations(t *testing.T) {
+	defaultLocationsAWS := map[string]*v1.VolumeSnapshotLocation{
+		"aws": arktest.NewTestVolumeSnapshotLocation().WithName("aws-us-east-2").VolumeSnapshotLocation,
+	}
+	defaultLocationsFake := map[string]*v1.VolumeSnapshotLocation{
+		"fake-provider": arktest.NewTestVolumeSnapshotLocation().WithName("some-name").VolumeSnapshotLocation,
+	}
 
 	multipleLocationNames := []string{"aws-us-west-1", "aws-us-east-1"}
 
@@ -463,7 +391,7 @@ func TestDefaultAndValidateSnapshotLocations(t *testing.T) {
 		name                                string
 		backup                              *arktest.TestBackup
 		locations                           []*arktest.TestVolumeSnapshotLocation
-		defaultLocations                    map[string]string
+		defaultLocations                    map[string]*v1.VolumeSnapshotLocation
 		expectedVolumeSnapshotLocationNames []string // adding these in the expected order will allow to test with better msgs in case of a test failure
 		expectedErrors                      string
 		expectedSuccess                     bool
@@ -493,7 +421,7 @@ func TestDefaultAndValidateSnapshotLocations(t *testing.T) {
 			name:                                "no location name for the provider exists: the provider's default should be added",
 			backup:                              arktest.NewTestBackup().WithName("backup1").WithPhase(v1.BackupPhaseNew),
 			defaultLocations:                    defaultLocationsAWS,
-			expectedVolumeSnapshotLocationNames: []string{defaultLocationsAWS["aws"]},
+			expectedVolumeSnapshotLocationNames: []string{defaultLocationsAWS["aws"].Name},
 			expectedSuccess:                     true,
 		},
 		{
@@ -506,7 +434,7 @@ func TestDefaultAndValidateSnapshotLocations(t *testing.T) {
 			backup:                              arktest.NewTestBackup().WithName("backup1").WithPhase(v1.BackupPhaseNew).WithVolumeSnapshotLocations(dupLocationNames),
 			locations:                           arktest.NewTestVolumeSnapshotLocation().WithName(dupLocationNames[0]).WithProviderConfig(dupLocationList),
 			defaultLocations:                    defaultLocationsFake,
-			expectedVolumeSnapshotLocationNames: []string{dupLocationNames[0], defaultLocationsFake["fake-provider"]},
+			expectedVolumeSnapshotLocationNames: []string{dupLocationNames[0], defaultLocationsFake["fake-provider"].Name},
 			expectedSuccess:                     true,
 		},
 	}
@@ -519,7 +447,8 @@ func TestDefaultAndValidateSnapshotLocations(t *testing.T) {
 			)
 
 			c := &backupController{
-				snapshotLocationLister: sharedInformers.Ark().V1().VolumeSnapshotLocations().Lister(),
+				snapshotLocationLister:   sharedInformers.Ark().V1().VolumeSnapshotLocations().Lister(),
+				defaultSnapshotLocations: test.defaultLocations,
 			}
 
 			// set up a Backup object to represent what we expect to be passed to backupper.Backup()
@@ -529,15 +458,23 @@ func TestDefaultAndValidateSnapshotLocations(t *testing.T) {
 				require.NoError(t, sharedInformers.Ark().V1().VolumeSnapshotLocations().Informer().GetStore().Add(location.VolumeSnapshotLocation))
 			}
 
-			errs := c.defaultAndValidateSnapshotLocations(backup, test.defaultLocations)
+			providerLocations, errs := c.validateAndGetSnapshotLocations(backup)
 			if test.expectedSuccess {
 				for _, err := range errs {
-					require.NoError(t, errors.New(err), "defaultAndValidateSnapshotLocations unexpected error: %v", err)
+					require.NoError(t, errors.New(err), "validateAndGetSnapshotLocations unexpected error: %v", err)
 				}
-				require.Equal(t, test.expectedVolumeSnapshotLocationNames, backup.Spec.VolumeSnapshotLocations)
+
+				var locations []string
+				for _, loc := range providerLocations {
+					locations = append(locations, loc.Name)
+				}
+
+				sort.Strings(test.expectedVolumeSnapshotLocationNames)
+				sort.Strings(locations)
+				require.Equal(t, test.expectedVolumeSnapshotLocationNames, locations)
 			} else {
 				if len(errs) == 0 {
-					require.Error(t, nil, "defaultAndValidateSnapshotLocations expected error")
+					require.Error(t, nil, "validateAndGetSnapshotLocations expected error")
 				}
 				require.Contains(t, errs, test.expectedErrors)
 			}

--- a/pkg/util/test/fake_block_store.go
+++ b/pkg/util/test/fake_block_store.go
@@ -104,10 +104,6 @@ func (bs *FakeBlockStore) GetVolumeInfo(volumeID, volumeAZ string) (string, *int
 }
 
 func (bs *FakeBlockStore) GetVolumeID(pv runtime.Unstructured) (string, error) {
-	if bs.Error != nil {
-		return "", bs.Error
-	}
-
 	return bs.VolumeID, nil
 }
 


### PR DESCRIPTION
This PR is completely still a work in progress, but wanted to get folks' input, particularly on the second commit..

I introduced a new struct, `backup.Request`, that embeds an `*arkv1api.Backup` and also has fields for holding an `*arkv1api.BackupStorageLocation`, `[]*arkv1api.VolumeSnapshotLocation`, and other objects related to a backup that are needed to actually execute it.  The backup controller instantiates it, adds some of the fields, then the Backupper in `pkg/backup` accepts it and populates some additional fields before passing it down to the other structs involved in backups.  The main goal with doing this was to avoid continued expansion of the parameter list across all the types in `pkg/backup` - I think keeping these things in a single struct is more reasonable.  What do you all think?  Good path to continue on?