### PR TITLE
fix backup storage location example YAMLs

### DIFF
--- a/examples/aws/05-ark-backupstoragelocation.yaml
+++ b/examples/aws/05-ark-backupstoragelocation.yaml
@@ -22,6 +22,5 @@ spec:
   provider: aws
   objectStorage:
     bucket: <YOUR_BUCKET> 
-    config:
-      region: <YOUR_REGION>
-
+  config:
+    region: <YOUR_REGION>

--- a/examples/ibm/05-ark-backupstoragelocation.yaml
+++ b/examples/ibm/05-ark-backupstoragelocation.yaml
@@ -22,7 +22,7 @@ spec:
   provider: aws
   objectStorage:
     bucket: <YOUR_BUCKET> 
-    config:
-      s3ForcePathStyle: "true"
-      s3Url:  <YOUR_URL_ACCESS_POINT>
-      region: <YOUR_REGION>
+  config:
+    s3ForcePathStyle: "true"
+    s3Url:  <YOUR_URL_ACCESS_POINT>
+    region: <YOUR_REGION>

--- a/examples/minio/05-ark-backupstoragelocation.yaml
+++ b/examples/minio/05-ark-backupstoragelocation.yaml
@@ -19,9 +19,12 @@ metadata:
   name: default
   namespace: heptio-ark
 spec:
-  provider: azure
+  provider: aws
   objectStorage:
-    bucket: <YOUR_BLOB_CONTAINER> 
+    bucket: ark
   config:
-    resourceGroup: <YOUR_STORAGE_RESOURCE_GROUP>
-    storageAccount: <YOUR_STORAGE_ACCOUNT>
+    region: minio
+    s3ForcePathStyle: "true"
+    s3Url: http://minio.heptio-ark.svc:9000
+    
+

--- a/examples/minio/10-ark-config.yaml
+++ b/examples/minio/10-ark-config.yaml
@@ -18,17 +18,3 @@ kind: Config
 metadata:
   namespace: heptio-ark
   name: default
-backupStorageProvider:
-  name: aws
-  bucket: ark
-  # Uncomment the below line to enable restic integration.
-  # The format for resticLocation is <bucket>[/<prefix>],
-  # e.g. "my-restic-bucket" or "my-restic-bucket/repos".
-  # This MUST be a different bucket than the main Ark bucket
-  # specified just above.
-  # resticLocation: <YOUR_RESTIC_LOCATION>
-  config:
-    region: minio
-    s3ForcePathStyle: "true"
-    s3Url: http://minio.heptio-ark.svc:9000
-


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

Just noticed we have some indentation issues with our sample `BackupStorageLocation` YAMLs, and minio didn't get a sample BSL.