### PR TITLE
Change link for the support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ See [the list of releases][6] to find out about feature changes.
 [29]: https://heptio.github.io/ark/
 [30]: /docs/troubleshooting.md
 
-[99]: support-matrix.md
+[99]: /docs/support-matrix.md


### PR DESCRIPTION
The support-matrix.md has been moved to the docs folder, hence the link in the readme didn't work anymore.
