### PR TITLE
Drop volumes matching name ServiceAccountName-token-

### DIFF
--- a/pkg/restore/pod_action_test.go
+++ b/pkg/restore/pod_action_test.go
@@ -43,18 +43,21 @@ func TestPodActionExecute(t *testing.T) {
 				WithSpec("serviceAccountName", "foo").
 				WithSpecField("volumes", []interface{}{}).
 				WithSpecField("containers", []interface{}{}).
+				WithSpecField("initContainers", []interface{}{}).
 				Unstructured,
 			expectedErr: false,
 			expectedRes: NewTestUnstructured().WithName("pod-1").WithSpec("foo").
 				WithSpec("serviceAccountName", "foo").
 				WithSpecField("volumes", []interface{}{}).
 				WithSpecField("containers", []interface{}{}).
+				WithSpecField("initContainers", []interface{}{}).
 				Unstructured,
 		},
 		{
 			name: "volumes matching prefix ServiceAccount-token- should be deleted",
 			obj: NewTestUnstructured().WithName("pod-1").
 				WithSpec("serviceAccountName", "foo").
+				WithSpecField("initContainers", []interface{}{}).
 				WithSpecField("volumes", []interface{}{
 					map[string]interface{}{"name": "foo"},
 					map[string]interface{}{"name": "foo-token-foo"},
@@ -62,6 +65,7 @@ func TestPodActionExecute(t *testing.T) {
 			expectedErr: false,
 			expectedRes: NewTestUnstructured().WithName("pod-1").
 				WithSpec("serviceAccountName", "foo").
+				WithSpecField("initContainers", []interface{}{}).
 				WithSpecField("volumes", []interface{}{
 					map[string]interface{}{"name": "foo"},
 				}).WithSpecField("containers", []interface{}{}).Unstructured,
@@ -71,6 +75,7 @@ func TestPodActionExecute(t *testing.T) {
 			obj: NewTestUnstructured().WithName("svc-1").
 				WithSpec("serviceAccountName", "foo").
 				WithSpecField("volumes", []interface{}{}).
+				WithSpecField("initContainers", []interface{}{}).
 				WithSpecField("containers", []interface{}{
 					map[string]interface{}{
 						"volumeMounts": []interface{}{
@@ -88,7 +93,43 @@ func TestPodActionExecute(t *testing.T) {
 			expectedRes: NewTestUnstructured().WithName("svc-1").
 				WithSpec("serviceAccountName", "foo").
 				WithSpecField("volumes", []interface{}{}).
+				WithSpecField("initContainers", []interface{}{}).
 				WithSpecField("containers", []interface{}{
+					map[string]interface{}{
+						"volumeMounts": []interface{}{
+							map[string]interface{}{
+								"name": "foo",
+							},
+						},
+					},
+				}).
+				Unstructured,
+		},
+		{
+			name: "initContainer volumeMounts matching prefix ServiceAccount-token- should be deleted",
+			obj: NewTestUnstructured().WithName("svc-1").
+				WithSpec("serviceAccountName", "foo").
+				WithSpecField("volumes", []interface{}{}).
+				WithSpecField("containers", []interface{}{}).
+				WithSpecField("initContainers", []interface{}{
+					map[string]interface{}{
+						"volumeMounts": []interface{}{
+							map[string]interface{}{
+								"name": "foo",
+							},
+							map[string]interface{}{
+								"name": "foo-token-foo",
+							},
+						},
+					},
+				}).
+				Unstructured,
+			expectedErr: false,
+			expectedRes: NewTestUnstructured().WithName("svc-1").
+				WithSpec("serviceAccountName", "foo").
+				WithSpecField("volumes", []interface{}{}).
+				WithSpecField("containers", []interface{}{}).
+				WithSpecField("initContainers", []interface{}{
 					map[string]interface{}{
 						"volumeMounts": []interface{}{
 							map[string]interface{}{


### PR DESCRIPTION
Continuation of #843 and #840 

Addresses #909 

There does not appear to be a test file for the restic_restore_action.go file so this is one of those "this should not break anything, I hope..." I just don't know enough about this project (or go testing in general) to create a test file from scratch. 

To that end it compiles, and in go that is a good sign.