### PR TITLE
Remove broken references to unexisting docs.

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -45,7 +45,7 @@ When you run `ark backup create test-backup`:
 
 1. The `BackupController` makes a call to the object storage service -- for example, AWS S3 -- to upload the backup file.
 
-By default, `ark backup create` makes disk snapshots of any persistent volumes. You can adjust the snapshots by specifying additional flags. See [the CLI help][30] for more information. Snapshots can be disabled with the option `--snapshot-volumes=false`.
+By default, `ark backup create` makes disk snapshots of any persistent volumes. You can adjust the snapshots by specifying additional flags. Run `ark backup create --help` to see available flags. Snapshots can be disabled with the option `--snapshot-volumes=false`.
 
 ![19]
 
@@ -70,4 +70,4 @@ Likewise, if a backup object exists in Kubernetes but not in object storage, it 
 [20]: https://kubernetes.io/docs/concepts/api-extension/custom-resources/#customresourcedefinitions
 [21]: https://kubernetes.io/docs/concepts/api-extension/custom-resources/#custom-controllers
 [22]: https://github.com/coreos/etcd
-[30]: https://github.com/heptio/ark/blob/master/docs/cli-reference/ark_create_backup.md
+[10]: hooks.md

--- a/docs/config-definition.md
+++ b/docs/config-definition.md
@@ -128,7 +128,7 @@ spec:
 
 ### Parameter Options
 
-The list of configurable options for the `ark server` deployment can be found on the [CLI reference][12] document.
+The list of configurable options for the `ark server` deployment can be found by running `ark server --help`.
 
 
 
@@ -142,6 +142,5 @@ The list of configurable options for the `ark server` deployment can be found on
 [9]: #example
 [10]: http://docs.aws.amazon.com/kms/latest/developerguide/overview.html
 [11]: #deployment
-[12]: cli-reference/ark_server.md
 [13]: #sample-deployment
 [14]: #parameter-options

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -19,7 +19,7 @@ If you periodically back up your cluster's resources, you are able to return to 
 
 2. A disaster happens and you need to recreate your resources.
 
-3. Update the [Ark server deployment][3], adding the argument for the `server` command flag `restore-only` set to `true`. This prevents Backup objects from being created or deleted during your Restore process.
+3. Update the Ark server deployment, adding the argument for the `server` command flag `restore-only` set to `true`. This prevents Backup objects from being created or deleted during your Restore process.
 
 4. Create a restore with your most recent Ark Backup:
     ```
@@ -50,4 +50,3 @@ ark restore create --from-backup <BACKUP-NAME>
 
 [0]: #disaster-recovery
 [1]: #cluster-migration
-[3]: cli-reference/ark_server#options


### PR DESCRIPTION
Closes #934 

Got rid of references to `cli-reference` documentation from other docs.