### PR TITLE
remove pvProviderExists param from NewRestoreController

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -649,7 +649,6 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]*api.V
 		s.sharedInformerFactory.Ark().V1().Backups(),
 		s.sharedInformerFactory.Ark().V1().BackupStorageLocations(),
 		s.sharedInformerFactory.Ark().V1().VolumeSnapshotLocations(),
-		false,
 		s.logger,
 		s.logLevel,
 		newPluginManager,

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -43,7 +43,6 @@ import (
 	"github.com/heptio/ark/pkg/persistence"
 	"github.com/heptio/ark/pkg/plugin"
 	"github.com/heptio/ark/pkg/restore"
-	"github.com/heptio/ark/pkg/util/boolptr"
 	"github.com/heptio/ark/pkg/util/collections"
 	kubeutil "github.com/heptio/ark/pkg/util/kube"
 	"github.com/heptio/ark/pkg/util/logging"
@@ -72,7 +71,6 @@ type restoreController struct {
 	restoreClient          arkv1client.RestoresGetter
 	backupClient           arkv1client.BackupsGetter
 	restorer               restore.Restorer
-	pvProviderExists       bool
 	backupLister           listers.BackupLister
 	restoreLister          listers.RestoreLister
 	backupLocationLister   listers.BackupStorageLocationLister
@@ -94,7 +92,6 @@ func NewRestoreController(
 	backupInformer informers.BackupInformer,
 	backupLocationInformer informers.BackupStorageLocationInformer,
 	snapshotLocationInformer informers.VolumeSnapshotLocationInformer,
-	pvProviderExists bool,
 	logger logrus.FieldLogger,
 	restoreLogLevel logrus.Level,
 	newPluginManager func(logrus.FieldLogger) plugin.Manager,
@@ -107,7 +104,6 @@ func NewRestoreController(
 		restoreClient:          restoreClient,
 		backupClient:           backupClient,
 		restorer:               restorer,
-		pvProviderExists:       pvProviderExists,
 		backupLister:           backupInformer.Lister(),
 		restoreLister:          restoreInformer.Lister(),
 		backupLocationLister:   backupLocationInformer.Lister(),
@@ -300,11 +296,6 @@ func (c *restoreController) validateAndComplete(restore *api.Restore, pluginMana
 	// validate included/excluded namespaces
 	for _, err := range collections.ValidateIncludesExcludes(restore.Spec.IncludedNamespaces, restore.Spec.ExcludedNamespaces) {
 		restore.Status.ValidationErrors = append(restore.Status.ValidationErrors, fmt.Sprintf("Invalid included/excluded namespace lists: %v", err))
-	}
-
-	// validate that PV provider exists if we're restoring PVs
-	if boolptr.IsSetToTrue(restore.Spec.RestorePVs) && !c.pvProviderExists {
-		restore.Status.ValidationErrors = append(restore.Status.ValidationErrors, "Server is not configured for PV snapshot restores")
 	}
 
 	// validate that exactly one of BackupName and ScheduleName have been specified

--- a/pkg/controller/restore_controller_test.go
+++ b/pkg/controller/restore_controller_test.go
@@ -105,7 +105,6 @@ func TestFetchBackupInfo(t *testing.T) {
 				sharedInformers.Ark().V1().Backups(),
 				sharedInformers.Ark().V1().BackupStorageLocations(),
 				sharedInformers.Ark().V1().VolumeSnapshotLocations(),
-				false,
 				logger,
 				logrus.InfoLevel,
 				func(logrus.FieldLogger) plugin.Manager { return pluginManager },
@@ -199,7 +198,6 @@ func TestProcessRestoreSkips(t *testing.T) {
 				sharedInformers.Ark().V1().Backups(),
 				sharedInformers.Ark().V1().BackupStorageLocations(),
 				sharedInformers.Ark().V1().VolumeSnapshotLocations(),
-				false, // pvProviderExists
 				logger,
 				logrus.InfoLevel,
 				nil,
@@ -226,7 +224,6 @@ func TestProcessRestore(t *testing.T) {
 		restore                         *api.Restore
 		backup                          *api.Backup
 		restorerError                   error
-		allowRestoreSnapshots           bool
 		expectedErr                     bool
 		expectedPhase                   string
 		expectedValidationErrors        []string
@@ -311,25 +308,6 @@ func TestProcessRestore(t *testing.T) {
 			expectedErr:          false,
 			expectedPhase:        string(api.RestorePhaseInProgress),
 			expectedRestorerCall: NewRestore("foo", "bar", "backup-1", "ns-1", "", api.RestorePhaseInProgress).Restore,
-		},
-		{
-			name:                  "valid restore with RestorePVs=true gets executed when allowRestoreSnapshots=true",
-			location:              arktest.NewTestBackupStorageLocation().WithName("default").WithProvider("myCloud").WithObjectStorage("bucket").BackupStorageLocation,
-			restore:               NewRestore("foo", "bar", "backup-1", "ns-1", "", api.RestorePhaseNew).WithRestorePVs(true).Restore,
-			backup:                arktest.NewTestBackup().WithName("backup-1").WithStorageLocation("default").Backup,
-			allowRestoreSnapshots: true,
-			expectedErr:           false,
-			expectedPhase:         string(api.RestorePhaseInProgress),
-			expectedRestorerCall:  NewRestore("foo", "bar", "backup-1", "ns-1", "", api.RestorePhaseInProgress).WithRestorePVs(true).Restore,
-		},
-		{
-			name:                     "restore with RestorePVs=true fails validation when allowRestoreSnapshots=false",
-			location:                 arktest.NewTestBackupStorageLocation().WithName("default").WithProvider("myCloud").WithObjectStorage("bucket").BackupStorageLocation,
-			restore:                  NewRestore("foo", "bar", "backup-1", "ns-1", "", api.RestorePhaseNew).WithRestorePVs(true).Restore,
-			backup:                   arktest.NewTestBackup().WithName("backup-1").WithStorageLocation("default").Backup,
-			expectedErr:              false,
-			expectedPhase:            string(api.RestorePhaseFailedValidation),
-			expectedValidationErrors: []string{"Server is not configured for PV snapshot restores"},
 		},
 		{
 			name:          "restoration of nodes is not supported",
@@ -425,7 +403,6 @@ func TestProcessRestore(t *testing.T) {
 				sharedInformers.Ark().V1().Backups(),
 				sharedInformers.Ark().V1().BackupStorageLocations(),
 				sharedInformers.Ark().V1().VolumeSnapshotLocations(),
-				test.allowRestoreSnapshots,
 				logger,
 				logrus.InfoLevel,
 				func(logrus.FieldLogger) plugin.Manager { return pluginManager },
@@ -643,7 +620,6 @@ func TestvalidateAndCompleteWhenScheduleNameSpecified(t *testing.T) {
 		sharedInformers.Ark().V1().Backups(),
 		sharedInformers.Ark().V1().BackupStorageLocations(),
 		sharedInformers.Ark().V1().VolumeSnapshotLocations(),
-		false,
 		logger,
 		logrus.DebugLevel,
 		nil,


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

This code is no longer relevant since we don't have a single `persistentVolumeProvider` anymore.