### PR TITLE
Improve directions when location CRDs not deployed

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -299,7 +299,7 @@ func (s *server) run() error {
 
 	if _, err := s.arkClient.ArkV1().BackupStorageLocations(s.namespace).Get(s.config.defaultBackupLocation, metav1.GetOptions{}); err != nil {
 		s.logger.WithError(errors.WithStack(err)).
-			Warnf("Default backup storage location %q not found; backups must explicitly specify a location", s.config.defaultBackupLocation)
+			Warnf("A backup storage location named %s has been specified for the server to use by default, but no corresponding backup storage location exists. Backups with a location not matching the default will need to explicitly specify an existing location", s.config.defaultBackupLocation)
 	}
 
 	if err := s.initRestic(); err != nil {

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -150,7 +150,7 @@ func TestProcessBackupValidationFailures(t *testing.T) {
 		{
 			name:         "non-existent backup location fails validation",
 			backup:       arktest.NewTestBackup().WithName("backup-1").WithStorageLocation("nonexistent").Backup,
-			expectedErrs: []string{"Error getting backup storage location: backupstoragelocation.ark.heptio.com \"nonexistent\" not found"},
+			expectedErrs: []string{"a BackupStorageLocation CRD with the name specified in the backup spec needs to be created before this backup can be executed. Error: backupstoragelocation.ark.heptio.com \"nonexistent\" not found"},
 		},
 	}
 
@@ -370,8 +370,7 @@ func TestValidateAndGetSnapshotLocations(t *testing.T) {
 				arktest.NewTestVolumeSnapshotLocation().WithProvider("aws").WithName("aws-us-west-1"),
 				arktest.NewTestVolumeSnapshotLocation().WithProvider("fake-provider").WithName("some-name"),
 			},
-			expectedErrors:  "error getting volume snapshot location named random-name: volumesnapshotlocation.ark.heptio.com \"random-name\" not found",
-			expectedSuccess: false,
+			expectedErrors: "a VolumeSnapshotLocation CRD for the location random-name with the name specified in the backup spec needs to be created before this snapshot can be executed. Error: volumesnapshotlocation.ark.heptio.com \"random-name\" not found", expectedSuccess: false,
 		},
 		{
 			name:   "duplicate locationName per provider: should filter out dups",


### PR DESCRIPTION
Wonder if any or all of this would help nudge the user into understanding there's a `step 2` in using our default location/s, which is to deploy the corresponding CRD or any CRD.