### PR TITLE
Silence git detached HEAD advice in build container

### DIFF
--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -17,6 +17,7 @@ FROM golang:1.10-alpine3.8
 RUN apk add --update --no-cache git bash && \
     mkdir -p /go/src/k8s.io && \
     cd /go/src/k8s.io && \
+    git config --global advice.detachedHead false && \
     git clone -b kubernetes-1.11.0 https://github.com/kubernetes/code-generator && \
     git clone -b kubernetes-1.11.0 https://github.com/kubernetes/apimachinery && \
     go get golang.org/x/tools/cmd/goimports && \


### PR DESCRIPTION
When the `ark-builder` container is created during a make run, the following output appears in the terminal in red:

```
...
Executing busybox-1.28.4-r1.trigger
OK: 28 MiB in 25 packages
Cloning into 'code-generator'...
Note: checking out '6702109cc68eb6fe6350b83e14407c8d7309fd1a'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

Cloning into 'apimachinery'...
Note: checking out '103fd098999dc9c0c88536f5c9ad2e5da39373ae'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

Note: checking out '40a48ad93fbe707101afb2099b738471f70594ec'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.
...
```

This message is innocuous in this case, but the wall of red text can be confusing. Suppress the advice since the detached HEAD state is on purpose.

Signed-off-by: Nolan Brubaker <nolan@heptio.com>