### PR TITLE
AWS: Ensure that the order returned by ListObjects is consistent

### DIFF
--- a/pkg/cloudprovider/aws/object_store.go
+++ b/pkg/cloudprovider/aws/object_store.go
@@ -18,6 +18,7 @@ package aws
 
 import (
 	"io"
+	"sort"
 	"strconv"
 	"time"
 
@@ -186,6 +187,11 @@ func (o *objectStore) ListObjects(bucket, prefix string) ([]string, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+
+	// ensure that returned objects are in a consistent order so that the deletion logic deletes the objects before
+	// the pseudo-folder prefix object for s3 providers (such as Quobyte) that return the pseudo-folder as an object.
+	// See https://github.com/heptio/ark/pull/999
+	sort.Sort(sort.Reverse(sort.StringSlice(ret)))
 
 	return ret, nil
 }


### PR DESCRIPTION
When a backup is deleted, the delete method uses ListObjects to get a list of
files it needs to delete in s3. Different s3 implementations may return
the object lists in different, even non-deterministic orders, which can
result in the deletion not working because ark tries to delete a non empty folder
before it tries to delete the files in the folder.

Signed-off-by: Bastian Hofmann <bashofmann@gmail.com>