### PR TITLE
goreleaser scripts for building/creating a release on a workstation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,53 @@
+# Copyright 2018 the Heptio Ark contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dist: _output
+builds:
+  - main: ./cmd/ark/main.go
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    ignore:
+      # don't build arm/arm64 for darwin or windows
+      - goos: darwin
+        goarch: arm
+      - goos: darwin
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -X "github.com/heptio/ark/pkg/buildinfo.Version={{ .Version }}" -X "github.com/heptio/ark/pkg/buildinfo.GitSHA={{ .Env.GIT_SHA }}" -X "github.com/heptio/ark/pkg/buildinfo.GitTreeState={{ .Env.GIT_TREE_STATE }}"
+archive:
+  name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+  files:
+    - LICENSE
+    - examples/**/*
+checksum:
+  name_template: 'CHECKSUM'
+snapshot:
+  name_template: "{{ .Env.GIT_SHA }}"
+release:
+  github:
+    owner: heptio
+    name: ark
+  draft: true

--- a/Makefile
+++ b/Makefile
@@ -233,3 +233,6 @@ clean:
 	docker rmi $(BUILDER_IMAGE)
 
 ci: all verify test
+
+goreleaser:
+	hack/goreleaser.sh

--- a/hack/goreleaser.sh
+++ b/hack/goreleaser.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Copyright 2018 the Heptio Ark contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# $PUBLISH must explicitly be set to 'true' for goreleaser
+# to publish the release to GitHub.
+if [ "${PUBLISH:-}" != "true" ]; then
+    SKIP_PUBLISH="--skip-publish"
+else
+    SKIP_PUBLISH=""
+fi
+
+if [ -z "${GITHUB_TOKEN}" ]; then
+    echo "GITHUB_TOKEN must be set"
+    exit 1
+fi
+
+# TODO derive this from the major+minor version
+if [ -z "${RELEASE_NOTES_FILE}" ]; then
+    echo "RELEASE_NOTES_FILE must be set"
+    exit 1
+fi
+
+export GIT_SHA=$(git describe --tags --always)
+
+GIT_DIRTY=$(git status --porcelain 2> /dev/null)
+if [[ -z "${GIT_DIRTY}" ]]; then
+    export GIT_TREE_STATE=clean
+else
+    export GIT_TREE_STATE=dirty
+fi
+
+goreleaser release \
+    --rm-dist \
+    --release-notes="${RELEASE_NOTES_FILE}" \
+    "${SKIP_PUBLISH}"


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

This is an MVP for using goreleaser to build binaries and create a GH release.  It's intended to be run on a developer's laptop, where goreleaser and go are expected to be installed.  The developer must also have a GitHub API token set up, with "repository" scope access to the heptio/ark repo.

Current incantation to run it is:
```
GITHUB_TOKEN=foo RELEASE_NOTES_FILE=<CHANGELOG-major.minor.md> make goreleaser
```

Input welcome!