### PR TITLE
fix goreleaser bugs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,9 +36,9 @@ builds:
       - goos: windows
         goarch: arm64
     ldflags:
-      - -X "github.com/heptio/ark/pkg/buildinfo.Version={{ .Version }}" -X "github.com/heptio/ark/pkg/buildinfo.GitSHA={{ .Env.GIT_SHA }}" -X "github.com/heptio/ark/pkg/buildinfo.GitTreeState={{ .Env.GIT_TREE_STATE }}"
+      - -X "github.com/heptio/ark/pkg/buildinfo.Version={{ .Tag }}" -X "github.com/heptio/ark/pkg/buildinfo.GitSHA={{ .Env.GIT_SHA }}" -X "github.com/heptio/ark/pkg/buildinfo.GitTreeState={{ .Env.GIT_TREE_STATE }}"
 archive:
-  name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+  name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
   files:
     - LICENSE
     - examples/**/*

--- a/hack/goreleaser.sh
+++ b/hack/goreleaser.sh
@@ -18,15 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# $PUBLISH must explicitly be set to 'true' for goreleaser
-# to publish the release to GitHub.
-if [ "${PUBLISH:-}" != "true" ]; then
-    SKIP_PUBLISH="--skip-publish"
-else
-    SKIP_PUBLISH=""
-fi
-
-if [ -z "${GITHUB_TOKEN}" ]; then
+if [[ -z "${GITHUB_TOKEN}" ]]; then
     echo "GITHUB_TOKEN must be set"
     exit 1
 fi
@@ -46,7 +38,15 @@ else
     export GIT_TREE_STATE=dirty
 fi
 
-goreleaser release \
-    --rm-dist \
-    --release-notes="${RELEASE_NOTES_FILE}" \
-    "${SKIP_PUBLISH}"
+# $PUBLISH must explicitly be set to 'true' for goreleaser
+# to publish the release to GitHub.
+if [[ "${PUBLISH:-}" != "true" ]]; then
+    goreleaser release \
+        --rm-dist \
+        --release-notes="${RELEASE_NOTES_FILE}" \
+        --skip-publish
+else
+    goreleaser release \
+        --rm-dist \
+        --release-notes="${RELEASE_NOTES_FILE}"
+fi


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

- use `.Tag` instead of `.Version` to include the leading `v` in both artifact names and ldflags.
- fix issue when `$SKIP_PUBLISH` is empty.
