### PR TITLE
0.9 backports

### DIFF
--- a/pkg/cloudprovider/aws/object_store.go
+++ b/pkg/cloudprovider/aws/object_store.go
@@ -18,6 +18,7 @@ package aws
 
 import (
 	"io"
+	"sort"
 	"strconv"
 	"time"
 
@@ -180,6 +181,11 @@ func (o *objectStore) ListObjects(bucket, prefix string) ([]string, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+
+	// ensure that returned objects are in a consistent order so that the deletion logic deletes the objects before
+	// the pseudo-folder prefix object for s3 providers (such as Quobyte) that return the pseudo-folder as an object.
+	// See https://github.com/heptio/ark/pull/999
+	sort.Sort(sort.Reverse(sort.StringSlice(ret)))
 
 	return ret, nil
 }

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -372,6 +372,8 @@ const (
 // - Limit ranges go before pods or controllers so pods can use them.
 // - Pods go before controllers so they can be explicitly restored and potentially
 //	 have restic restores run before controllers adopt the pods.
+// - Custom Resource Definitions come before Custom Resource so that they can be
+//   restored with their corresponding CRD.
 var defaultResourcePriorities = []string{
 	"namespaces",
 	"persistentvolumes",
@@ -382,6 +384,7 @@ var defaultResourcePriorities = []string{
 	"limitranges",
 	"pods",
 	"replicaset",
+	"customresourcedefinitions",
 }
 
 func applyConfigDefaults(c *api.Config, logger logrus.FieldLogger) {

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -364,6 +364,7 @@ const (
 )
 
 // - Namespaces go first because all namespaced resources depend on them.
+// - Storage Classes are needed to create PVs and PVCs correctly.
 // - PVs go before PVCs because PVCs depend on them.
 // - PVCs go before pods or controllers so they can be mounted as volumes.
 // - Secrets and config maps go before pods or controllers so they can be mounted
@@ -376,6 +377,7 @@ const (
 //   restored with their corresponding CRD.
 var defaultResourcePriorities = []string{
 	"namespaces",
+	"storageclasses",
 	"persistentvolumes",
 	"persistentvolumeclaims",
 	"secrets",


### PR DESCRIPTION
backport of #962 (a fix for #424)
backport of #999 (fix for s3 compatible object list ordering)
backport of #971 (a fix for #594)