### PR TITLE
Move clearing up of metadata before plugin's actions

### DIFF
--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -740,6 +740,12 @@ func (ctx *context) restoreResource(resource, namespace, resourcePath string) (a
 			}
 		}
 
+		// clear out non-core metadata fields & status
+		if obj, err = resetMetadataAndStatus(obj); err != nil {
+			addToResult(&errs, namespace, err)
+			continue
+		}
+
 		for _, action := range applicableActions {
 			if !action.selector.Matches(labels.Set(obj.GetLabels())) {
 				continue
@@ -763,12 +769,6 @@ func (ctx *context) restoreResource(resource, namespace, resourcePath string) (a
 			}
 
 			obj = unstructuredObj
-		}
-
-		// clear out non-core metadata fields & status
-		if obj, err = resetMetadataAndStatus(obj); err != nil {
-			addToResult(&errs, namespace, err)
-			continue
 		}
 
 		// necessary because we may have remapped the namespace


### PR DESCRIPTION
As discussed in #965 and in this [slack thread](https://kubernetes.slack.com/archives/C6VCGP4MT/p1540932054141300):
I'd like to move clearing up of metadata before plugin execution. In such case I will be able to set ownerReference.