### PR TITLE
lower some noisy logs to debug level

### DIFF
--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -122,7 +122,7 @@ func shouldSync(location *arkv1api.BackupStorageLocation, now time.Time, backupS
 }
 
 func (c *backupSyncController) run() {
-	c.logger.Info("Checking for backup storage locations to sync into cluster")
+	c.logger.Debug("Checking for existing backup storage locations to sync into cluster")
 
 	locations, err := c.backupStorageLocationLister.BackupStorageLocations(c.namespace).List(labels.Everything())
 	if err != nil {

--- a/pkg/controller/schedule_controller.go
+++ b/pkg/controller/schedule_controller.go
@@ -246,7 +246,7 @@ func (c *scheduleController) submitBackupIfDue(item *api.Schedule, cronSchedule 
 	)
 
 	if !isDue {
-		log.WithField("nextRunTime", nextRunTime).Info("Schedule is not due, skipping")
+		log.WithField("nextRunTime", nextRunTime).Debug("Schedule is not due, skipping")
 		return nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

The backup sync and schedule controllers now run every minute by default.  Lower their "doing something" log statement levels to debug so the log doesn't fill up with these once a minute if it's not on debug.