### PR TITLE
Fix check for non-found PV

### DIFF
--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -1007,8 +1007,7 @@ status:
 
 			// Only set up the client expectation if the test has the proper prerequisites
 			if test.haveSnapshot || test.reclaimPolicy != "Delete" {
-				var empty *unstructured.Unstructured
-				pvClient.On("Get", mock.Anything, metav1.GetOptions{}).Return(empty, nil)
+				pvClient.On("Get", unstructuredPV.GetName(), metav1.GetOptions{}).Return(&unstructured.Unstructured{}, k8serrors.NewNotFound(schema.GroupResource{Resource: "persistentvolumes"}, unstructuredPV.GetName()))
 			}
 
 			pvToRestore := unstructuredPV.DeepCopy()


### PR DESCRIPTION
We were checking for nil, but were getting back an empty
*unstructured.Unstructured{} instead, along with a NotFound error.
Change the logic to check for the NotFound error instead of a nil
object.

Signed-off-by: Andy Goldstein <andy.goldstein@gmail.com>