### PR TITLE
package version-specific example YAML with each release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 _obj
 _test
 _output
+config
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 dist: _output
+before:
+  hooks:
+    - ./hack/set-example-tags.sh
 builds:
   - main: ./cmd/ark/main.go
     env:
@@ -41,7 +44,7 @@ archive:
   name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
   files:
     - LICENSE
-    - examples/**/*
+    - config/**/*
 checksum:
   name_template: 'CHECKSUM'
 snapshot:

--- a/docs/aws-config.md
+++ b/docs/aws-config.md
@@ -123,10 +123,10 @@ For more information, see [the AWS documentation on IAM users][14].
 
 ## Credentials and configuration
 
-In the Ark root directory, run the following to first set up namespaces, RBAC, and other scaffolding. To run in a custom namespace, make sure that you have edited the YAML files to specify the namespace. See [Run in custom namespace][0].
+In the Ark directory (i.e. where you extracted the release tarball), run the following to first set up namespaces, RBAC, and other scaffolding. To run in a custom namespace, make sure that you have edited the YAML files to specify the namespace. See [Run in custom namespace][0].
 
 ```bash
-kubectl apply -f examples/common/00-prereqs.yaml
+kubectl apply -f config/common/00-prereqs.yaml
 ```
 
 Create a Secret. In the directory of the credentials file you just created, run:
@@ -139,23 +139,23 @@ kubectl create secret generic cloud-credentials \
 
 Specify the following values in the example files:
 
-* In `examples/aws/05-ark-backupstoragelocation.yaml`:
+* In `config/aws/05-ark-backupstoragelocation.yaml`:
 
   * Replace `<YOUR_BUCKET>` and `<YOUR_REGION>` (for S3 backup storage, region is optional and will be queried from the AWS S3 API if not provided). See the [BackupStorageLocation definition][21] for details.
 
-* In `examples/aws/06-ark-volumesnapshotlocation.yaml`:
+* In `config/aws/06-ark-volumesnapshotlocation.yaml`:
 
   * Replace `<YOUR_REGION>`. See the [VolumeSnapshotLocation definition][6] for details.
 
-* (Optional, use only to specify multiple volume snapshot locations) In `examples/aws/10-deployment.yaml` (or `examples/aws/10-deployment-kube2iam.yaml`, as appropriate):
+* (Optional, use only to specify multiple volume snapshot locations) In `config/aws/10-deployment.yaml` (or `config/aws/10-deployment-kube2iam.yaml`, as appropriate):
 
   * Uncomment the `--default-volume-snapshot-locations` and replace provider locations with the values for your environment.
 
-* (Optional) If you run the nginx example, in file `examples/nginx-app/with-pv.yaml`:
+* (Optional) If you run the nginx example, in file `config/nginx-app/with-pv.yaml`:
 
     * Replace `<YOUR_STORAGE_CLASS_NAME>` with `gp2`. This is AWS's default `StorageClass` name.
 
-* (Optional) If you have multiple clusters and you want to support migration of resources between them, in file `examples/aws/10-deployment.yaml`:
+* (Optional) If you have multiple clusters and you want to support migration of resources between them, in file `config/aws/10-deployment.yaml`:
 
     * Uncomment the environment variable `AWS_CLUSTER_NAME` and replace `<YOUR_CLUSTER_NAME>` with the current cluster's name. When restoring backup, it will make Ark (and cluster it's running on) claim ownership of AWS volumes created from snapshots taken on different cluster.
     The best way to get the current cluster's name is to either check it with used deployment tool or to read it directly from the EC2 instances tags. 
@@ -185,9 +185,9 @@ Specify the following values in the example files:
 In the root of your Ark directory, run:
 
   ```bash
-  kubectl apply -f examples/aws/05-ark-backupstoragelocation.yaml
-  kubectl apply -f examples/aws/06-ark-volumesnapshotlocation.yaml
-  kubectl apply -f examples/aws/10-deployment.yaml
+  kubectl apply -f config/aws/05-ark-backupstoragelocation.yaml
+  kubectl apply -f config/aws/06-ark-volumesnapshotlocation.yaml
+  kubectl apply -f config/aws/10-deployment.yaml
   ```
 
 ## ALTERNATIVE: Setup permissions using kube2iam
@@ -281,7 +281,7 @@ It can be set up for Ark by creating a role that will have required permissions,
       --policy-name heptio-ark-policy \
       --policy-document file://./heptio-ark-policy.json
     ```
-4. Update `AWS_ACCOUNT_ID` & `HEPTIO_ARK_ROLE_NAME` in the file `examples/aws/10-deployment-kube2iam.yaml`:
+4. Update `AWS_ACCOUNT_ID` & `HEPTIO_ARK_ROLE_NAME` in the file `config/aws/10-deployment-kube2iam.yaml`:
 
     ```
     ---
@@ -301,7 +301,7 @@ It can be set up for Ark by creating a role that will have required permissions,
     ...
     ```
 
-5. Run Ark deployment using the file `examples/aws/10-deployment-kube2iam.yaml`.
+5. Run Ark deployment using the file `config/aws/10-deployment-kube2iam.yaml`.
 
 [0]: namespace.md
 [5]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html

--- a/docs/azure-config.md
+++ b/docs/azure-config.md
@@ -105,10 +105,10 @@ To integrate Ark with Azure, you must create an Ark-specific [service principal]
 
 ## Credentials and configuration
 
-In the Ark root directory, run the following to first set up namespaces, RBAC, and other scaffolding. To run in a custom namespace, make sure that you have edited the YAML file to specify the namespace. See [Run in custom namespace][0].
+In the Ark directory (i.e. where you extracted the release tarball), run the following to first set up namespaces, RBAC, and other scaffolding. To run in a custom namespace, make sure that you have edited the YAML file to specify the namespace. See [Run in custom namespace][0].
 
 ```bash
-kubectl apply -f examples/common/00-prereqs.yaml
+kubectl apply -f config/common/00-prereqs.yaml
 ```
 
 Now you need to create a Secret that contains all the environment variables you just set. The command looks like the following:
@@ -125,15 +125,15 @@ kubectl create secret generic cloud-credentials \
 
 Now that you have your Azure credentials stored in a Secret, you need to replace some placeholder values in the template files. Specifically, you need to change the following:
 
-* In file `examples/azure/05-ark-backupstoragelocation.yaml`:
+* In file `config/azure/05-ark-backupstoragelocation.yaml`:
 
   * Replace `<YOUR_BLOB_CONTAINER>`, `<YOUR_STORAGE_RESOURCE_GROUP>`, and `<YOUR_STORAGE_ACCOUNT>`. See the [BackupStorageLocation definition][21] for details.
 
-* In file `examples/azure/06-ark-volumesnapshotlocation.yaml`:
+* In file `config/azure/06-ark-volumesnapshotlocation.yaml`:
 
   * Replace `<YOUR_TIMEOUT>`. See the [VolumeSnapshotLocation definition][8] for details.
 
-* (Optional, use only if you need to specify multiple volume snapshot locations) In `examples/azure/00-ark-deployment.yaml`:
+* (Optional, use only if you need to specify multiple volume snapshot locations) In `config/azure/00-ark-deployment.yaml`:
 
   * Uncomment the `--default-volume-snapshot-locations` and replace provider locations with the values for your environment.
 
@@ -142,7 +142,7 @@ Now that you have your Azure credentials stored in a Secret, you need to replace
 In the root of your Ark directory, run:
 
   ```bash
-  kubectl apply -f examples/azure/
+  kubectl apply -f config/azure/
   ```
 
 [0]: namespace.md

--- a/docs/gcp-config.md
+++ b/docs/gcp-config.md
@@ -93,10 +93,10 @@ To integrate Heptio Ark with GCP, create an Ark-specific [Service Account][15]:
 If you run Google Kubernetes Engine (GKE), make sure that your current IAM user is a cluster-admin. This role is required to create RBAC objects.
 See [the GKE documentation][22] for more information.
 
-In the Ark root directory, run the following to first set up namespaces, RBAC, and other scaffolding. To run in a custom namespace, make sure that you have edited the YAML files to specify the namespace. See [Run in custom namespace][0].
+In the Ark directory (i.e. where you extracted the release tarball), run the following to first set up namespaces, RBAC, and other scaffolding. To run in a custom namespace, make sure that you have edited the YAML files to specify the namespace. See [Run in custom namespace][0].
 
 ```bash
-kubectl apply -f examples/common/00-prereqs.yaml
+kubectl apply -f config/common/00-prereqs.yaml
 ```
 
 Create a Secret. In the directory of the credentials file you just created, run:
@@ -111,15 +111,15 @@ kubectl create secret generic cloud-credentials \
 
 Specify the following values in the example files:
 
-* In file `examples/gcp/05-ark-backupstoragelocation.yaml`:
+* In file `config/gcp/05-ark-backupstoragelocation.yaml`:
 
   * Replace `<YOUR_BUCKET>`. See the [BackupStorageLocation definition][7] for details.
 
-* (Optional) If you run the nginx example, in file `examples/nginx-app/with-pv.yaml`:
+* (Optional) If you run the nginx example, in file `config/nginx-app/with-pv.yaml`:
 
     * Replace `<YOUR_STORAGE_CLASS_NAME>` with `standard`. This is GCP's default `StorageClass` name.
 
-* (Optional, use only if you need to specify multiple volume snapshot locations) In `examples/gcp/10-deployment.yaml`:
+* (Optional, use only if you need to specify multiple volume snapshot locations) In `config/gcp/10-deployment.yaml`:
 
   * Uncomment the `--default-volume-snapshot-locations` and replace provider locations with the values for your environment.
 
@@ -128,9 +128,9 @@ Specify the following values in the example files:
 In the root of your Ark directory, run:
 
   ```bash
-  kubectl apply -f examples/gcp/05-ark-backupstoragelocation.yaml
-  kubectl apply -f examples/gcp/06-ark-volumesnapshotlocation.yaml
-  kubectl apply -f examples/gcp/10-deployment.yaml
+  kubectl apply -f config/gcp/05-ark-backupstoragelocation.yaml
+  kubectl apply -f config/gcp/06-ark-volumesnapshotlocation.yaml
+  kubectl apply -f config/gcp/10-deployment.yaml
   ```
 
   [0]: namespace.md

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -16,29 +16,31 @@ See [Set up Ark on your platform][3] for how to configure Ark for a production e
 
 ### Download
 
-Clone or fork the Ark repository:
+1. Download the [latest release's][26] tarball for your platform.
 
-```
-git clone git@github.com:heptio/ark.git
-```
+1. Extract the tarball:
+    ```bash
+    tar -xzf <RELEASE-TARBALL-NAME>.tar.gz -C /dir/to/extract/to 
+    ```
+    We'll refer to the directory you extracted to as the "Ark directory" in subsequent steps.
 
-NOTE: Make sure to check out the appropriate version. We recommend that you check out the latest tagged version. The master branch is under active development and might not be stable.
+1. Move the `ark` binary from the Ark directory to somewhere in your PATH.
 
 ### Set up server
 
 These instructions start the Ark server and a Minio instance that is accessible from within the cluster only. See the following section for information about configuring your cluster for outside access to Minio. Outside access is required to access logs and run `ark describe` commands.
 
-1.  Start the server and the local storage service. In the root directory of Ark, run:
+1.  Start the server and the local storage service. In the Ark directory, run:
 
     ```bash
-    kubectl apply -f examples/common/00-prereqs.yaml
-    kubectl apply -f examples/minio/
+    kubectl apply -f config/common/00-prereqs.yaml
+    kubectl apply -f config/minio/
     ```
 
 1. Deploy the example nginx application:
 
     ```bash
-    kubectl apply -f examples/nginx-app/base.yaml
+    kubectl apply -f config/nginx-app/base.yaml
     ```
 
 1. Check to see that both the Ark and nginx deployments are successfully created:
@@ -94,12 +96,6 @@ In this case:
 1.  Keep the Service type as `ClusterIP`.
 
 1.  In `examples/minio/05-ark-backupstoragelocation.yaml`, uncomment the `publicUrl` line and provide the URL and port of your Ingress as the value of the `publicUrl` field.
-
-### Install client
-
-[Download the client][26].
-
-Make sure that you install somewhere in your PATH.
 
 ### Back up
 
@@ -204,9 +200,9 @@ snapshots, it is safe to remove the `heptio-ark` namespace and everything else c
 example:
 
 ```
-kubectl delete -f examples/common/
-kubectl delete -f examples/minio/
-kubectl delete -f examples/nginx-app/base.yaml
+kubectl delete -f config/common/
+kubectl delete -f config/minio/
+kubectl delete -f config/nginx-app/base.yaml
 ```
 
 [3]: install-overview.md

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -51,7 +51,7 @@ spec.
 We are going to walk through using both pre and post hooks for freezing a file system. Freezing the
 file system is useful to ensure that all pending disk I/O operations have completed prior to taking a snapshot.
 
-We will be using [example/nginx-app/with-pv.yaml][2] for this example. Follow the [steps for your provider][3] to
+We will be using [examples/nginx-app/with-pv.yaml][2] for this example. Follow the [steps for your provider][3] to
 setup this example.
 
 ### Annotations

--- a/docs/ibm-config.md
+++ b/docs/ibm-config.md
@@ -37,10 +37,10 @@ Several comments:
 
 ## Credentials and configuration
 
-In the Ark root directory, run the following to first set up namespaces, RBAC, and other scaffolding. To run in a custom namespace, make sure that you have edited the YAML files to specify the namespace. See [Run in custom namespace][0].
+In the Ark directory (i.e. where you extracted the release tarball), run the following to first set up namespaces, RBAC, and other scaffolding. To run in a custom namespace, make sure that you have edited the YAML files to specify the namespace. See [Run in custom namespace][0].
 
 ```bash
-kubectl apply -f examples/common/00-prereqs.yaml
+kubectl apply -f config/common/00-prereqs.yaml
 ```
 
 Create a Secret. In the directory of the credentials file you just created, run:
@@ -53,11 +53,11 @@ kubectl create secret generic cloud-credentials \
 
 Specify the following values in the example files:
 
-* In `examples/ibm/05-ark-backupstoragelocation.yaml`:
+* In `config/ibm/05-ark-backupstoragelocation.yaml`:
 
   * Replace `<YOUR_BUCKET>`, `<YOUR_REGION>` and `<YOUR_URL_ACCESS_POINT>`. See the [BackupStorageLocation definition][6] for details.
 
-* (Optional) If you run the nginx example, in file `examples/nginx-app/with-pv.yaml`:
+* (Optional) If you run the nginx example, in file `config/nginx-app/with-pv.yaml`:
 
     * Replace `<YOUR_STORAGE_CLASS_NAME>` with your `StorageClass` name.
 
@@ -66,8 +66,8 @@ Specify the following values in the example files:
 In the root of your Ark directory, run:
 
   ```bash
-  kubectl apply -f examples/ibm/05-ark-backupstoragelocation.yaml
-  kubectl apply -f examples/ibm/10-deployment.yaml
+  kubectl apply -f config/ibm/05-ark-backupstoragelocation.yaml
+  kubectl apply -f config/ibm/10-deployment.yaml
   ```
 
   [0]: namespace.md

--- a/docs/install-overview.md
+++ b/docs/install-overview.md
@@ -43,7 +43,7 @@ After you set up the Ark server, try these examples:
 1. Start the sample nginx app:
 
     ```bash
-    kubectl apply -f examples/nginx-app/base.yaml
+    kubectl apply -f config/nginx-app/base.yaml
     ```
 
 1. Create a backup:
@@ -73,7 +73,7 @@ After you set up the Ark server, try these examples:
 1. Start the sample nginx app:
 
     ```bash
-    kubectl apply -f examples/nginx-app/with-pv.yaml
+    kubectl apply -f config/nginx-app/with-pv.yaml
     ```
 
 1. Create a backup with PV snapshotting:

--- a/docs/namespace.md
+++ b/docs/namespace.md
@@ -6,7 +6,7 @@ you run Ark client commands.
 
 ## Edit the example files
 
-The Ark repository includes [a set of examples][0] that you can use to set up your Ark server. The
+The Ark release tarballs include a set of example configs that you can use to set up your Ark server. The
 examples place the server and backup/schedule/restore/etc. data in the `heptio-ark` namespace.
 
 To run the server in another namespace, you edit the relevant files, changing `heptio-ark` to
@@ -16,7 +16,9 @@ To store your backups, schedules, restores, and config in another namespace, you
 files, changing `heptio-ark` to your desired namespace. You also need to create the
 `cloud-credentials` secret in your desired namespace.
 
-For all cloud providers, edit `https://github.com/heptio/ark/blob/master/examples/common/00-prereqs.yaml`. This file defines:
+First, ensure you've [downloaded & extracted the latest release][0].
+
+For all cloud providers, edit `config/common/00-prereqs.yaml`. This file defines:
 
 * CustomResourceDefinitions for the Ark objects (backups, schedules, restores, downloadrequests, etc.)
 * The namespace where the Ark server runs
@@ -29,34 +31,34 @@ For all cloud providers, edit `https://github.com/heptio/ark/blob/master/example
 
 For AWS, edit:
 
-* `https://github.com/heptio/ark/blob/master/examples/aws/05-ark-backupstoragelocation.yaml`
-* `https://github.com/heptio/ark/blob/master/examples/aws/06-ark-volumesnapshotlocation.yaml`
-* `https://github.com/heptio/ark/blob/master/examples/aws/10-deployment.yaml`
+* `config/aws/05-ark-backupstoragelocation.yaml`
+* `config/aws/06-ark-volumesnapshotlocation.yaml`
+* `config/aws/10-deployment.yaml`
 
 
 ### Azure
 
 For Azure, edit:
 
-* `https://github.com/heptio/ark/blob/master/examples/azure/00-ark-deployment.yaml`
-* `https://github.com/heptio/ark/blob/master/examples/azure/05-ark-backupstoragelocation.yaml`
-* `https://github.com/heptio/ark/blob/master/examples/azure/06-ark-volumesnapshotlocation.yaml`
+* `config/azure/00-ark-deployment.yaml`
+* `config/azure/05-ark-backupstoragelocation.yaml`
+* `config/azure/06-ark-volumesnapshotlocation.yaml`
 
 ### GCP
 
 For GCP, edit:
 
-* `https://github.com/heptio/ark/blob/master/examples/gcp/05-ark-backupstoragelocation.yaml`
-* `https://github.com/heptio/ark/blob/master/examples/gcp/06-ark-volumesnapshotlocation.yaml`
-* `https://github.com/heptio/ark/blob/master/examples/gcp/10-deployment.yaml`
+* `config/gcp/05-ark-backupstoragelocation.yaml`
+* `config/gcp/06-ark-volumesnapshotlocation.yaml`
+* `config/gcp/10-deployment.yaml`
 
 
 ### IBM
 
 For IBM, edit:
 
-* `https://github.com/heptio/ark/blob/master/examples/ibm/05-ark-backupstoragelocation.yaml`
-* `https://github.com/heptio/ark/blob/master/examples/ibm/10-deployment.yaml`
+* `config/ibm/05-ark-backupstoragelocation.yaml`
+* `config/ibm/10-deployment.yaml`
 
 
 ## Specify the namespace in client commands
@@ -69,4 +71,4 @@ ark client config set namespace=<NAMESPACE_VALUE>
 
 
 
-[0]: https://github.com/heptio/ark/tree/master/examples
+[0]: quickstart.md#download

--- a/docs/restic.md
+++ b/docs/restic.md
@@ -30,20 +30,20 @@ cross-volume-type data migrations. Stay tuned as this evolves!
 
 ### Instructions
 
-1. Download an updated Ark client from the [latest release][3], and move it to a location in your PATH.
+1. Ensure you've [downloaded & extracted the latest release][3].
 
-1. From the Ark root directory, run the following to create new custom resource definitions:
+1. In the Ark directory (i.e. where you extracted the release tarball), run the following to create new custom resource definitions:
 
     ```bash
-    kubectl apply -f examples/common/00-prereqs.yaml
+    kubectl apply -f config/common/00-prereqs.yaml
     ```
 
 1. Run one of the following for your platform to create the daemonset:
 
-    - AWS: `kubectl apply -f examples/aws/20-restic-daemonset.yaml`
-    - Azure: `kubectl apply -f examples/azure/20-restic-daemonset.yaml`
-    - GCP: `kubectl apply -f examples/gcp/20-restic-daemonset.yaml`
-    - Minio: `kubectl apply -f examples/minio/30-restic-daemonset.yaml`
+    - AWS: `kubectl apply -f config/aws/20-restic-daemonset.yaml`
+    - Azure: `kubectl apply -f config/azure/20-restic-daemonset.yaml`
+    - GCP: `kubectl apply -f config/gcp/20-restic-daemonset.yaml`
+    - Minio: `kubectl apply -f config/minio/30-restic-daemonset.yaml`
 
 You're now ready to use Ark with restic.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -50,7 +50,7 @@ Alternatively, you might be able to use the Service's `spec.loadBalancerIP` fiel
 ### Ark reports `custom resource not found` errors when starting up.
 
 Ark's server will not start if the required Custom Resource Definitions are not found in Kubernetes. Apply
-the `examples/common/00-prereqs.yaml` file to create these definitions, then restart Ark.
+the `config/common/00-prereqs.yaml` file to create these definitions, then restart Ark.
 
 ### `ark backup logs` returns a `SignatureDoesNotMatch` error
 
@@ -69,4 +69,3 @@ Here are some things to verify if you receive `SignatureDoesNotMatch` errors:
 [4]: https://github.com/heptio/ark/issues
 [5]: https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
 [25]: https://kubernetes.slack.com/messages/ark-dr
-[26]: get-started.md#minikube-configuration

--- a/docs/upgrading-to-v0.10.md
+++ b/docs/upgrading-to-v0.10.md
@@ -28,24 +28,25 @@ rearrange any pre-v0.10 data as part of the upgrade. We've provided a script to 
 
 ## Step-by-Step Upgrade Instructions
 
+1. Ensure you've [downloaded & extracted the latest release][5].
+
 1. Scale down your existing Ark deployment:
-```bash
-kubectl scale -n heptio-ark deploy/ark --replicas 0
-```
+    ```bash
+    kubectl scale -n heptio-ark deploy/ark --replicas 0
+    ```
 
-2. Re-apply the `00-prereqs.yaml` file to create new CRDs:
-```bash
-kubectl apply -f examples/common/00-prereqs.yaml
-```
+1. In the Ark directory (i.e. where you extracted the release tarball), re-apply the `00-prereqs.yaml` file to create new CRDs:
+    ```bash
+    kubectl apply -f config/common/00-prereqs.yaml
+    ```
 
-3. Create one or more [BackupStorageLocation][1] resources based on the examples provided in the `examples/` directory for your platform, using information from
-the existing `Config` resource as necessary.
-4. If you're using Ark to take PV snapshots, create one or more [VolumeSnapshotLocation][2] resources based on the examples provided in the `examples/` directory for your platform, using information from
-the existing `Config` resource as necessary.
+1. Create one or more [BackupStorageLocation][1] resources based on the examples provided in the `config/` directory for your platform, using information from the existing `Config` resource as necessary.
 
-5. Perform the one-time object storage migration detailed [here][3].
+1. If you're using Ark to take PV snapshots, create one or more [VolumeSnapshotLocation][2] resources based on the examples provided in the `config/` directory for your platform, using information from the existing `Config` resource as necessary.
 
-6. In your Ark deployment YAML (see the `examples/` directory for samples), specify flags to the `ark server` command under the container's `args`:
+1. Perform the one-time object storage migration detailed [here][3].
+
+1. In your Ark deployment YAML (see the `config/` directory for samples), specify flags to the `ark server` command under the container's `args`:
 
     a. The names of the `BackupStorageLocation` and `VolumeSnapshotLocation(s)` that should be used by default for backups. If defaults are set here, 
     users won't need to explicitly specify location names when creating backups (though they still can, if they want to store backups/snapshots in
@@ -68,20 +69,21 @@ the existing `Config` resource as necessary.
     `--restic-timeout` | 1h | how long backups/restores of pod volumes should be allowed to run before timing out (previously `podVolumeOperationTimeout` in the `Config` resource in pre-v0.10 versions)
     `--restore-only` | false | run in a mode where only restores are allowed; backups, schedules, and garbage-collection are all disabled
 
-7.If you are using any plugins, update the Ark deployment YAML to reference the latest image tag for your plugins. This can be found under the `initContainers` section of your deployment YAML.
+1. If you are using any plugins, update the Ark deployment YAML to reference the latest image tag for your plugins. This can be found under the `initContainers` section of your deployment YAML.
 
-8. Apply your updated Ark deployment YAML to your cluster and ensure the pod(s) starts up successfully.
+1. Apply your updated Ark deployment YAML to your cluster and ensure the pod(s) starts up successfully.
 
-9. If you're using Ark's restic integration, ensure the daemon set pods have been re-created with the latest Ark image (if your daemon set YAML is using the `:latest` tag, you can delete the pods so they're recreated with an updated image).
+1. If you're using Ark's restic integration, ensure the daemon set pods have been re-created with the latest Ark image (if your daemon set YAML is using the `:latest` tag, you can delete the pods so they're recreated with an updated image).
 
-10. Once you've confirmed all of your settings have been migrated over correctly, delete the Config CRD:
-```bash
-kubectl delete -n heptio-ark config --all
-kubectl delete crd configs.ark.heptio.com
-```
+1. Once you've confirmed all of your settings have been migrated over correctly, delete the Config CRD:
+    ```bash
+    kubectl delete -n heptio-ark config --all
+    kubectl delete crd configs.ark.heptio.com
+    ```
 
 
 [1]: /api-types/backupstoragelocation.md
 [2]: /api-types/volumesnapshotlocation.md
 [3]: storage-layout-reorg-v0.10.md
 [4]: locations.md
+[5]: quickstart.md#download

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-The YAML config files in this directory can be used to quickly deploy a containerized Ark deployment.
+This directory contains sample YAML config files for running Ark on each core provider. Starting with v0.10, these files are packaged into [the Ark release tarballs][2], and we highly recommend that you use the packaged versions of these files to ensure compatibility with the released code. 
 
 * `common/`: Contains manifests to set up Ark. Can be used across cloud provider platforms. (Note that Azure requires its own deployment file due to its unique way of loading credentials).
 
@@ -10,3 +10,4 @@ The YAML config files in this directory can be used to quickly deploy a containe
 
 [0]: https://github.com/minio/minio
 [1]: /README.md#quickstart
+[2]: https://github.com/heptio/ark/releases

--- a/hack/set-example-tags.sh
+++ b/hack/set-example-tags.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright 2018 the Heptio Ark contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# this script copies all of the files under examples/ into a new directory,
+# config/ (which is gitignored so it doesn't result in the git
+# state being dirty, which would prevent goreleaser from running), and then
+# updates all of the image tags in those files to use $GIT_SHA (which will
+# be the release/tag name).
+
+rm -rf config/ && cp -r examples/ config/
+
+# the "-i'.bak'" flag to sed is necessary, with no space between the flag
+# and the value, for this to be compatible across BSD/OSX sed and GNU sed.
+# remove the ".bak" files afterwards (they're copies of the originals).
+find config/ -type f -name "*.yaml" | xargs sed -i'.bak' "s|gcr.io/heptio-images/ark:latest|gcr.io/heptio-images/ark:$GIT_SHA|g"
+find config/ -type f -name "*.bak" | xargs rm
+
+find config/ -type f -name "*.yaml" | xargs sed -i'.bak' "s|gcr.io/heptio-images/fsfreeze-pause:latest|gcr.io/heptio-images/fsfreeze-pause:$GIT_SHA|g"
+find config/ -type f -name "*.bak" | xargs rm


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

This updates the goreleaser process so it adjusts the image tag in each example YAML file to match the version of Ark being released.

Open to suggestions on the name of the directory that contains the examples within the archives - just can't be "examples" (unless we change the existing directory name in the repo) since goreleaser requires a clean git state before running.

I'll move on to updating our docs next.