### PR TITLE
Initialize empty schedule metrics on server init

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -502,6 +502,8 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 	}()
 	s.metrics = metrics.NewServerMetrics()
 	s.metrics.RegisterAllMetrics()
+	// Initialize manual backup metrics
+	s.metrics.InitSchedule("")
 
 	newPluginManager := func(logger logrus.FieldLogger) plugin.Manager {
 		return plugin.NewManager(logger, s.logLevel, s.pluginRegistry)


### PR DESCRIPTION
When backups are run manually (outside of a schedule) the metrics will be counted for `ark_*{schedule=""}`. To prevent partial `NaN` metrics they will be initialised on server init.

The current behaviour creates e.g. only `ark_backup_failure_total` or `ark_backup_success_total` but never both on the first manual run. Afaict the `backupName` shall be included in the metrics in the future, when this is implemented the initialisation must be moved to the point in time, where the `backupName` is already known (I guess the `processBackup()` function in `pkg/controller/backup_controller.go`), but so far the server init should be most sufficient for the metrics init.