### PR TITLE
Delete spec.priority in pod restore action

### DIFF
--- a/pkg/restore/pod_action.go
+++ b/pkg/restore/pod_action.go
@@ -50,6 +50,9 @@ func (a *podAction) Execute(obj runtime.Unstructured, restore *api.Restore) (run
 	a.logger.Debug("deleting spec.NodeName")
 	delete(spec, "nodeName")
 
+	a.logger.Debug("deleting spec.priority")
+	delete(spec, "priority")
+
 	// if there are no volumes, then there can't be any volume mounts, so we're done.
 	if !collections.Exists(spec, "volumes") {
 		return obj, nil, nil

--- a/pkg/restore/pod_action_test.go
+++ b/pkg/restore/pod_action_test.go
@@ -40,12 +40,20 @@ func TestPodActionExecute(t *testing.T) {
 		{
 			name: "nodeName (only) should be deleted from spec",
 			obj: NewTestUnstructured().WithName("pod-1").WithSpec("nodeName", "foo").
-				WithSpec("serviceAccountName", "foo").
 				WithSpecField("containers", []interface{}{}).
 				Unstructured,
 			expectedErr: false,
 			expectedRes: NewTestUnstructured().WithName("pod-1").WithSpec("foo").
-				WithSpec("serviceAccountName", "foo").
+				WithSpecField("containers", []interface{}{}).
+				Unstructured,
+		},
+		{
+			name: "priority (only) should be deleted from spec",
+			obj: NewTestUnstructured().WithName("pod-1").WithSpec("priority", "foo").
+				WithSpecField("containers", []interface{}{}).
+				Unstructured,
+			expectedErr: false,
+			expectedRes: NewTestUnstructured().WithName("pod-1").WithSpec("foo").
 				WithSpecField("containers", []interface{}{}).
 				Unstructured,
 		},

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -1605,6 +1605,9 @@ func (obj *testUnstructured) WithMetadata(fields ...string) *testUnstructured {
 }
 
 func (obj *testUnstructured) WithSpec(fields ...string) *testUnstructured {
+	if _, found := obj.Object["spec"]; found {
+		panic("spec already set - you probably didn't mean to do this twice!")
+	}
 	return obj.withMap("spec", fields...)
 }
 


### PR DESCRIPTION
Fixes: #879 

Added deletion of field + test.
Also fixed another test (`nodeName (only) should be deleted from spec`) as it was 'green' even if I commented `//delete(spec, "nodeName")` in `pod_action.go`.

One remark:
I was testing it on cluster and without my fix I was able to add pod with spec.priority set if the priority on pod spec was equal to value defined in PriorityClass. I get an error only if I chenged value  in PriorityClass. 
But IMO it's better to delete this field.