### PR TITLE
Added GOFLAGS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ shell: build-dirs build-image
 	@# the volume bind-mount of $PWD/vendor/k8s.io/api is needed for code-gen to
 	@# function correctly (ref. https://github.com/kubernetes/kubernetes/pull/64567)
 	@docker run \
+		-e GOFLAGS \
 		-i $(TTY) \
 		--rm \
 		-u $$(id -u):$$(id -g) \


### PR DESCRIPTION
First time PR provider here :) Took a look at https://github.com/heptio/ark/issues/502. Not sure if you needed anything other than GOFLAGS, but if that's all that's needed, I think this PR ought to do it. Works for the -v flag, at least.

Fixes #502