### PR TITLE
add back missing link ref

### DIFF
--- a/docs/api-types/backupstoragelocation.md
+++ b/docs/api-types/backupstoragelocation.md
@@ -69,3 +69,4 @@ No parameters required.
 [1]: #gcp
 [2]: #azure
 [3]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
+[10]: http://docs.aws.amazon.com/kms/latest/developerguide/overview.html


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

Link [10] got dropped in the move from config to BSLs, added it back