### PR TITLE
Move changelog entries to their own files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Development release:
 
-  * _Example: Add XYZ support (#issue, @user)_
+  * [Unreleased Changes][9]
 
 ### Bug Fixes / Other Changes
   * add multizone/regional support to gcp (#765, @wwitzel3)
@@ -24,6 +24,7 @@
   * [CHANGELOG-0.4.md][2]
   * [CHANGELOG-0.3.md][1]
 
+[9]: https://github.com/heptio/ark/blob/master/changelogs/unreleased
 [8]: https://github.com/heptio/ark/blob/master/changelogs/CHANGELOG-0.10.md
 [7]: https://github.com/heptio/ark/blob/master/changelogs/CHANGELOG-0.9.md
 [6]: https://github.com/heptio/ark/blob/master/changelogs/CHANGELOG-0.8.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,15 @@
 # Contributing
 
-## Updating CHANGELOG.md
+## CHANGELOG 
 
-Authors are expected include an entry to the CHANGELOG.md under the `Development release` heading
-with their pull requests. During the process of creating a new release, entries from CHANGELOG.md will be
-moved to the changelog for the release.
+Authors are expected to include a changelog file with their pull requests. The changelog file
+should be a new file created in the `changelogs/unreleased` folder. The file should follow the
+naming convention of `issue-username` and the contents of the file should be your text for the
+changelog.
+
+    ark/changelogs/unreleased   <- folder
+        000-username            <- file
+
 
 ## DCO Sign off
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Authors are expected to include a changelog file with their pull requests. The changelog file
 should be a new file created in the `changelogs/unreleased` folder. The file should follow the
-naming convention of `issue-username` and the contents of the file should be your text for the
+naming convention of `pr-username` and the contents of the file should be your text for the
 changelog.
 
     ark/changelogs/unreleased   <- folder

--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,7 @@ clean:
 	docker rmi $(BUILDER_IMAGE)
 
 ci: all verify test
-
+changelog:
+	hack/changelog.sh
 goreleaser:
 	hack/goreleaser.sh

--- a/changelogs/unreleased/000-username
+++ b/changelogs/unreleased/000-username
@@ -1,0 +1,1 @@
+Example changelog entry.

--- a/changelogs/unreleased/000-username
+++ b/changelogs/unreleased/000-username
@@ -1,1 +1,0 @@
-Example changelog entry.

--- a/changelogs/unreleased/1048-ncdc
+++ b/changelogs/unreleased/1048-ncdc
@@ -1,0 +1,1 @@
+Remove default token from all service accounts

--- a/changelogs/unreleased/1051-omerlh
+++ b/changelogs/unreleased/1051-omerlh
@@ -1,0 +1,1 @@
+Added brew reference

--- a/changelogs/unreleased/1054-cbeneke
+++ b/changelogs/unreleased/1054-cbeneke
@@ -1,0 +1,1 @@
+Initialize empty schedule metrics on server init

--- a/changelogs/unreleased/1063-wwitzel3
+++ b/changelogs/unreleased/1063-wwitzel3
@@ -1,0 +1,1 @@
+Update CHANGELOGs

--- a/changelogs/unreleased/1069-gliptak
+++ b/changelogs/unreleased/1069-gliptak
@@ -1,0 +1,1 @@
+Update to go 1.11

--- a/changelogs/unreleased/765-wwitzel3
+++ b/changelogs/unreleased/765-wwitzel3
@@ -1,0 +1,1 @@
+add multizone/regional support to gcp

--- a/changelogs/unreleased/811-bashofmann
+++ b/changelogs/unreleased/811-bashofmann
@@ -1,0 +1,1 @@
+Allow to use AWS Signature v1 for creating signed AWS urls

--- a/changelogs/unreleased/879-mwieczorek
+++ b/changelogs/unreleased/879-mwieczorek
@@ -1,0 +1,1 @@
+Delete spec.priority in pod restore action

--- a/hack/changelog.sh
+++ b/hack/changelog.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2018 the Heptio Ark contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CHANGELOG_PATH='changelogs/unreleased'
+UNRELEASED=$(ls -t ${CHANGELOG_PATH})
+echo -e "Generating CHANGELOG markdown from ${CHANGELOG_PATH}\n"
+for entry in $UNRELEASED
+do
+    IFS=$'-' read -ra pruser <<<"$entry"
+    contents=$(cat ${CHANGELOG_PATH}/${entry})
+    echo "  * ${contents} (#${pruser[0]}, @${pruser[1]})"
+done
+echo -e "\nCopy and paste the list above in to the appropriate CHANGELOG file."
+echo "Be sure to run: git rm ${CHANGELOG_PATH}/*"


### PR DESCRIPTION
This deals with the issues of changelog entries causing conflicts for each PR.

- [x] Move changelog entries
- [x] Update CHANGELOG.md and CONTRIBUTING.md
- [x] Add helper that parses the `changelogs/unreleased` folder and generates markdown.

Closes #1112 