### PR TITLE
Fix minio setup job command

### DIFF
--- a/examples/minio/00-minio-deployment.yaml
+++ b/examples/minio/00-minio-deployment.yaml
@@ -112,7 +112,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - "mc --config-folder=/config config host add ark http://minio:9000 minio minio123 && mc --config-folder=/config mb -p ark/ark"
+        - "mc --config-dir=/config config host add ark http://minio:9000 minio minio123 && mc --config-dir=/config mb -p ark/ark"
         volumeMounts:
         - name: config
           mountPath: "/config"


### PR DESCRIPTION
My ark setup was failing, looking at the logs it was a failure from the minio setup job. When running
`oc -n heptio-ark logs pod/minio-setup-q8wwg` I saw:

```Incorrect Usage. flag provided but not defined: -config-folder
NAME:
  mc - Minio Client for cloud storage and filesystems.
USAGE:
  mc [FLAGS] COMMAND [COMMAND FLAGS | -h] [ARGUMENTS...]
COMMANDS:
  ls       list buckets and objects
  mb       make a bucket
  cat      display object contents
  pipe     stream STDIN to an object
  share    generate URL for temporary access to an object
  cp       copy objects
  mirror   synchronize object(s) to a remote site
  find     search for objects
  sql      run sql queries on objects
  stat     show object metadata
  diff     list differences in object name, size, and date between two buckets
  rm       remove objects
  event    configure object notifications
  watch    listen for object notification events
  policy   manage anonymous access to buckets and objects
  admin    manage minio servers
  session  resume interrupted operations
  config   configure minio client
  update   update mc to latest release
  version  show version info

GLOBAL FLAGS:
  --config-dir value, -C value  path to configuration folder (default: "/.mc")
  --quiet, -q                   disable progress bar display
  --no-color                    disable color theme
  --json                        enable JSON formatted output
  --debug                       enable debug output
  --insecure                    disable SSL certificate verification
  --help, -h                    show help
  --version, -v                 print the version

VERSION:
  RELEASE.2018-12-05T22-59-07Z
flag provided but not defined: -config-folder
```

Cleaning up ark, applying this fix, and reapplying example config fixed the issue. Looks like this was introduced in https://github.com/minio/mc/commit/f3eaa54a32f3f48c340e6c48e9960b294e5cc670