### PR TITLE
Fix output of Schedule Delete

### DIFF
--- a/changelogs/unreleased/1120-jwhitcraft
+++ b/changelogs/unreleased/1120-jwhitcraft
@@ -1,0 +1,1 @@
+Fixed the newline output when deleting a schedule.

--- a/pkg/cmd/cli/schedule/delete.go
+++ b/pkg/cmd/cli/schedule/delete.go
@@ -110,7 +110,7 @@ func Run(o *cli.DeleteOptions) error {
 			errs = append(errs, errors.WithStack(err))
 			continue
 		}
-		fmt.Printf("Schedule deleted: %v/n", s.Name)
+		fmt.Printf("Schedule deleted: %v\n", s.Name)
 	}
 	return kubeerrs.NewAggregate(errs)
 }


### PR DESCRIPTION
It should be `\n` and not `/n/` when doing the printf on a schedule delete.