### PR TITLE
ark version changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ about: Tell us about a problem you are experiencing
 
 **Environment:**
 
-- Ark version (use `ark version`):  
+- Ark version (use `ark version`): 
 - Kubernetes version (use `kubectl version`):
 - Kubernetes installer & version:
 - Cloud provider or hardware configuration:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,7 +39,7 @@ builds:
       - goos: windows
         goarch: arm64
     ldflags:
-      - -X "github.com/heptio/ark/pkg/buildinfo.Version={{ .Tag }}" -X "github.com/heptio/ark/pkg/buildinfo.GitSHA={{ .Env.GIT_SHA }}" -X "github.com/heptio/ark/pkg/buildinfo.GitTreeState={{ .Env.GIT_TREE_STATE }}"
+      - -X "github.com/heptio/ark/pkg/buildinfo.Version={{ .Tag }}" -X "github.com/heptio/ark/pkg/buildinfo.GitSHA={{ .FullCommit }}" -X "github.com/heptio/ark/pkg/buildinfo.GitTreeState={{ .Env.GIT_TREE_STATE }}"
 archive:
   name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
   files:
@@ -47,8 +47,6 @@ archive:
     - config/**/*
 checksum:
   name_template: 'CHECKSUM'
-snapshot:
-  name_template: "{{ .Env.GIT_SHA }}"
 release:
   github:
     owner: heptio

--- a/changelogs/unreleased/1124-skriss
+++ b/changelogs/unreleased/1124-skriss
@@ -1,0 +1,1 @@
+'ark version': show full git SHA & combine git tree state indicator with git SHA line

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -41,7 +41,7 @@ fi
 
 export CGO_ENABLED=0
 
-GIT_SHA=$(git describe --tags --always)
+GIT_SHA=$(git rev-parse HEAD)
 GIT_DIRTY=$(git status --porcelain 2> /dev/null)
 if [[ -z "${GIT_DIRTY}" ]]; then
   GIT_TREE_STATE=clean

--- a/hack/goreleaser.sh
+++ b/hack/goreleaser.sh
@@ -29,8 +29,6 @@ if [ -z "${RELEASE_NOTES_FILE}" ]; then
     exit 1
 fi
 
-export GIT_SHA=$(git describe --tags --always)
-
 GIT_DIRTY=$(git status --porcelain 2> /dev/null)
 if [[ -z "${GIT_DIRTY}" ]]; then
     export GIT_TREE_STATE=clean

--- a/hack/set-example-tags.sh
+++ b/hack/set-example-tags.sh
@@ -18,19 +18,20 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+GIT_TAG=$(git describe --tags --always)
+
 # this script copies all of the files under examples/ into a new directory,
-# config/ (which is gitignored so it doesn't result in the git
-# state being dirty, which would prevent goreleaser from running), and then
-# updates all of the image tags in those files to use $GIT_SHA (which will
-# be the release/tag name).
+# config/ (which is gitignored so it doesn't result in the git state being 
+# dirty, which would prevent goreleaser from running), and then updates all 
+# of the image tags in those files to use $GIT_TAG.
 
 rm -rf config/ && cp -r examples/ config/
 
 # the "-i'.bak'" flag to sed is necessary, with no space between the flag
 # and the value, for this to be compatible across BSD/OSX sed and GNU sed.
 # remove the ".bak" files afterwards (they're copies of the originals).
-find config/ -type f -name "*.yaml" | xargs sed -i'.bak' "s|gcr.io/heptio-images/ark:latest|gcr.io/heptio-images/ark:$GIT_SHA|g"
+find config/ -type f -name "*.yaml" | xargs sed -i'.bak' "s|gcr.io/heptio-images/ark:latest|gcr.io/heptio-images/ark:$GIT_TAG|g"
 find config/ -type f -name "*.bak" | xargs rm
 
-find config/ -type f -name "*.yaml" | xargs sed -i'.bak' "s|gcr.io/heptio-images/fsfreeze-pause:latest|gcr.io/heptio-images/fsfreeze-pause:$GIT_SHA|g"
+find config/ -type f -name "*.yaml" | xargs sed -i'.bak' "s|gcr.io/heptio-images/fsfreeze-pause:latest|gcr.io/heptio-images/fsfreeze-pause:$GIT_TAG|g"
 find config/ -type f -name "*.bak" | xargs rm

--- a/pkg/cmd/cli/bug/bug.go
+++ b/pkg/cmd/cli/bug/bug.go
@@ -71,7 +71,7 @@ about: Tell us about a problem you are experiencing
 
 **Environment:**
 
-- Ark version (use ` + "`ark version`" + `):{{.ArkVersion}} {{.GitCommit}} {{.GitTreeState}}
+- Ark version (use ` + "`ark version`" + `):{{.ArkVersion}} {{.GitCommit}}
 - Kubernetes version (use ` + "`kubectl version`" + `): 
 {{- if .KubectlVersion}}
 ` + "```" + `
@@ -109,7 +109,6 @@ func NewCommand() *cobra.Command {
 type ArkBugInfo struct {
 	ArkVersion     string
 	GitCommit      string
-	GitTreeState   string
 	RuntimeOS      string
 	RuntimeArch    string
 	KubectlVersion string
@@ -162,8 +161,7 @@ func getKubectlVersion() (string, error) {
 func newBugInfo(kubectlVersion string) *ArkBugInfo {
 	return &ArkBugInfo{
 		ArkVersion:     buildinfo.Version,
-		GitCommit:      buildinfo.GitSHA,
-		GitTreeState:   buildinfo.GitTreeState,
+		GitCommit:      buildinfo.FormattedGitSHA(),
 		RuntimeOS:      runtime.GOOS,
 		RuntimeArch:    runtime.GOARCH,
 		KubectlVersion: kubectlVersion}

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -30,8 +30,7 @@ func NewCommand() *cobra.Command {
 		Short: "Print the ark version and associated image",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("Version: %s\n", buildinfo.Version)
-			fmt.Printf("Git commit: %s\n", buildinfo.GitSHA)
-			fmt.Printf("Git tree state: %s\n", buildinfo.GitTreeState)
+			fmt.Printf("Git commit: %s\n", buildinfo.FormattedGitSHA())
 		},
 	}
 


### PR DESCRIPTION
Fixes #1111 

- removes `Git tree state` line
- uses full git SHA in `Git commit` line, with a `-dirty` suffix if git tree state is dirty