### PR TITLE
update links to point to get-started.md

### DIFF
--- a/docs/namespace.md
+++ b/docs/namespace.md
@@ -71,4 +71,4 @@ ark client config set namespace=<NAMESPACE_VALUE>
 
 
 
-[0]: quickstart.md#download
+[0]: get-started.md#download

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -49,7 +49,7 @@ After you publish your plugin, open a PR that adds your plugin to the appropriat
 [6]: https://docs.portworx.com/scheduler/kubernetes/ark.html
 [7]: https://github.com/StackPointCloud/ark-plugin-digitalocean
 [8]: https://github.com/heptio/ark-plugin-example/
-[9]: quickstart.md
+[9]: get-started.md
 [10]: https://kubernetes.slack.com/messages/ark-dr
 [11]: https://github.com/heptio/ark/issues
 [12]: https://github.com/aws/aws-sdk-go/aws

--- a/docs/upgrading-to-v0.10.md
+++ b/docs/upgrading-to-v0.10.md
@@ -86,4 +86,4 @@ rearrange any pre-v0.10 data as part of the upgrade. We've provided a script to 
 [2]: api-types/volumesnapshotlocation.md
 [3]: storage-layout-reorg-v0.10.md
 [4]: locations.md
-[5]: quickstart.md#download
+[5]: get-started.md#download


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

Looks like we missed updating a few links with the rename from `quickstart.md` to `get-started.md`.