### PR TITLE
Add note about kubeconfig in doc get-started.md

### DIFF
--- a/changelogs/unreleased/1131-hex108
+++ b/changelogs/unreleased/1131-hex108
@@ -1,0 +1,1 @@
+Add debugging-install link in doc get-started.md

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -8,6 +8,8 @@ For simplicity, the example uses Minio, an S3-compatible storage service that ru
 
 See [Set up Ark on your platform][3] for how to configure Ark for a production environment.
 
+If you encounter issues with installing or configuring, see [Debugging Installation Issues](debugging-install.md).
+
 ### Prerequisites
 
 * Access to a Kubernetes cluster, version 1.7 or later. Version 1.7.5 or later is required to run `ark backup delete`.


### PR DESCRIPTION
Signed-off-by: Jun Gong <jungong@tencent.com>

I followed instructions in [get-started](https://heptio.github.io/ark/v0.10.0/get-started). When executing ark command, there is an error: `An error occurred: invalid configuration: no configuration has been provided`. In this PR, add a note for it.