### PR TITLE
Added protoc-gen-go version info

### DIFF
--- a/docs/build-from-scratch.md
+++ b/docs/build-from-scratch.md
@@ -59,7 +59,7 @@ Run `make update` to regenerate files if you make the following changes:
 
 Run [generate-proto.sh][13] to regenerate files if you make the following changes:
 
-* Add/edit/remove protobuf message or service definitions. These changes require the [proto compiler][14]. 
+* Add/edit/remove protobuf message or service definitions. These changes require the [proto compiler][14] and compiler plugin `protoc-gen-go` version v1.0.0. 
 
 ### Cross compiling
 


### PR DESCRIPTION
Just a minor fix regarding expected `protoc-gen-go` version. Trying to regenerate protobufs with newer ones (v1.1.0 and v.1.2.0) causes incompatibility with project's vendored version, that brakes the build. 